### PR TITLE
change name for conformant plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contribution Guidelines
-This document is intended to be a living summary of conventions & best practices for development within Zowe CLI Plug-in for IBM Db2.
+This document is intended to be a living summary of conventions & best practices for development within IBM® Db2® Plug-in for Zowe CLI.
 
 ## Primary Contribution Guidelines
 The following information is critical to working with the code, running/writing/maintaining automated tests, developing consistent syntax in your plug-in, and ensuring that your plug-in integrates with Zowe CLI properly:
@@ -14,6 +14,6 @@ The following information is critical to working with the code, running/writing/
 Versioning conventions for Zowe CLI and Plug-ins| [Versioning Guidelines](https://github.com/zowe/zowe-cli/blob/master/docs/MaintainerVersioning.md) |
 
 ## Contribution Guidelines Specific to the Db2 Plug-in
-The following guidelines apply specifically to this Zowe CLI Plug-in for IBM Db2:
+The following guidelines apply specifically to this IBM® Db2® Plug-in for Zowe CLI:
 
 None at this time.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,9 +29,7 @@ node('ca-jenkins-agent') {
 
     // Protected branch property definitions
     pipeline.protectedBranches.addMap([
-        [name: "master", tag: "daily", prerelease: "alpha", dependencies: ["@zowe/imperative": "daily"]],
-        [name: "beta", tag: "beta", prerelease: "beta", dependencies: ["@zowe/imperative": "beta"]],
-        [name: "latest", tag: "latest", dependencies: ["@zowe/imperative": "latest"], autoDeploy: true],
+        [name: "master", tag: "latest", dependencies: ["@zowe/imperative": "latest"]],
         [name: "lts-incremental", tag: "lts-incremental", level: SemverLevel.MINOR, dependencies: ["@brightside/imperative": "lts-incremental"]],
         [name: "lts-stable", tag: "lts-stable", level: SemverLevel.PATCH, dependencies: ["@brightside/imperative": "lts-stable"]]
     ])

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Zowe CLI Plug-in for IBM® Db2® for z/OS®
+# IBM® Db2® Plug-in for Zowe CLI
 
 [![codecov](https://codecov.io/gh/zowe/zowe-cli-db2-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/zowe/zowe-cli-db2-plugin)
 
-The Zowe CLI plug-in for IBM® Db2® Database lets you interact with Db2 for z/OS to perform tasks
+The IBM® Db2® Plug-in for Zowe CLI lets you interact with Db2 for z/OS to perform tasks
 with modern development tools to automate typical workloads more efficiently.
 The plug-in also enables you to interact with Db2 to advance continuous integration to validate product
 quality and stability.
 
-Zowe CLI Plug-in for IBM Db2 Database lets you execute SQL statements against a Db2 region,
+IBM® Db2® Plug-in for Zowe CLI lets you execute SQL statements against a Db2 region,
 export a Db2 table, and call a stored procedure. The plug-in also exposes its API
 so that the plug-in can be used directly in other products.
 
@@ -34,13 +34,13 @@ Before you install the plug-in, meet the following prerequisites:
 ## Build the Plug-in from Source
 **Follow these steps:**
 
-1. The first time that you download the Zowe CLI plug-in for Db2 from the GitHub repository,
+1. The first time that you download the IBM® Db2® Plug-in for Zowe CLI from the GitHub repository,
    issue the following command against the local directory:
 
     ```
     npm install
     ```
-    The command installs the required Zowe CLI Plug-in for Db2 dependencies and several development tools.
+    The command installs the required IBM® Db2® Plug-in for Zowe CLI dependencies and several development tools.
     When necessary, you can run the task at any time to update the tools.
 
 2. To build your code changes, issue the following command:
@@ -51,20 +51,20 @@ Before you install the plug-in, meet the following prerequisites:
     **Note:** When you update `package.json` to include new dependencies, or when you pull changes
     that affect `package.json`, issue the `npm update` command to download the dependencies.
 
-## Install the Zowe CLI Plug-in for Db2
+## Install the IBM® Db2® Plug-in for Zowe CLI
 **Follow these steps:**
 
 1.  Meet the prerequisites.
 2.  Install the plug-in:
     ```
-    zowe plugins install @zowe/db2@latest
+    zowe plugins install @zowe/db2-for-zowe-cli
     ```
 
-    **Note**: The `latest` npm tag installs a version of the product that is intended for public consumption. You can use different npm tags to install other versions of the product. For example, you can install with the `@daily` tag to try new features that have not been fully validated. For more information about tag usage, see [NPM Tag Names](https://github.com/zowe/zowe-cli/blob/master/docs/MaintainerVersioning.md#npm-tag-names).
+    **Note**: The `latest` npm tag installs a version of the product that is intended for public consumption. You can use different npm tags to install other versions of the product. See [NPM Tag Names](https://github.com/zowe/zowe-cli/blob/master/docs/MaintainerVersioning.md#npm-tag-names).
     
 3.  (Optional) Verify the installation:
     ```
-    zowe plugins validate @zowe/db2
+    zowe plugins validate @zowe/db2-for-zowe-cli
     ```
     When you install the plug-in successfully, the following message displays:
     ```

--- a/__tests__/__snapshots__/imperative.test.ts.snap
+++ b/__tests__/__snapshots__/imperative.test.ts.snap
@@ -7,7 +7,7 @@ Object {
   ],
   "name": "db2",
   "pluginHealthCheck": "./lib/HealthCheck.handler",
-  "productDisplayName": "CLI Plug-in for IBM Db2",
+  "productDisplayName": "IBM® Db2® Plug-in for Zowe CLI",
   "profiles": Array [
     Object {
       "schema": Object {

--- a/__tests__/__src__/environment/TestEnvironment.ts
+++ b/__tests__/__src__/environment/TestEnvironment.ts
@@ -157,7 +157,7 @@ export class TestEnvironment {
         installScript += "# Install plugin from root of project\n";
         installScript += "bright plugins install ../../../../\n";
         installScript += "# Validate installed plugin\n";
-        installScript += "bright plugins validate @zowe/db2\n";
+        installScript += "bright plugins validate @zowe/db2-for-zowe-cli\n";
         installScript += "# Check that the plugin help is available\n";
         installScript += "bright db2 --help\n";
         const scriptPath = testEnvironment.workingDir + "/install_plugin.sh";
@@ -166,7 +166,7 @@ export class TestEnvironment {
         const output = runCliScript(scriptPath, testEnvironment, []);
         if (output.status !== 0) {
             throw new ImperativeError({
-                msg: "Install of '@zowe/db2' plugin failed! You should delete the script: \n'" + scriptPath + "' " +
+                msg: "Install of '@zowe/db2-for-zowe-cli' plugin failed! You should delete the script: \n'" + scriptPath + "' " +
                 "after reviewing it to check for possible errors.\n Output of the plugin install command:\n" + output.stderr.toString() +
                 output.stdout.toString() +
                 TempTestProfiles.GLOBAL_INSTALL_NOTE

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@zowe/db2",
+  "name": "@zowe/db2-for-zowe-cli",
   "version": "3.0.2-alpha.201907121346",
-  "description": "CLI Plug-in for IBM Db2",
+  "description": "IBM® Db2® Plug-in for Zowe CLI",
   "author": "CA T&C Brightside",
   "license": "EPL-2.0",
   "main": "lib/index.js",
@@ -37,8 +37,8 @@
     "ibm_db": "2.5.0"
   },
   "peerDependencies": {
-    "@zowe/imperative": "^3.0.0",
-    "@zowe/cli": "^3.0.0"
+    "@zowe/imperative": "^4.0.0",
+    "@zowe/cli": "^5.0.0"
   },
   "devDependencies": {
     "@types/ibm_db": "^2.0.2",

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -29,7 +29,7 @@ export class Constants {
      * @static
      * @memberof Constants
      */
-    public static readonly DISPLAY_NAME: string = "CLI Plug-in for IBM Db2";
+    public static readonly DISPLAY_NAME: string = "IBM® Db2® Plug-in for Zowe CLI";
 
     /**
      * The Db2 plugin top level description


### PR DESCRIPTION
- Master now deploys to `@latest` as part of CI
- Name changed
- Some naming changed on various md files
- Remove peerDep warnings

Signed-off-by: zFernand0 <fernando.rijocedeno@broadcom.com>