### PR TITLE
Update ibm_db dependency to support Node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "configurationModule": "lib/imperative.js"
   },
   "dependencies": {
-    "ibm_db": "2.5.0"
+    "ibm_db": "2.6.0"
   },
   "peerDependencies": {
     "@zowe/imperative": "^4.0.0",


### PR DESCRIPTION
Per [this issue](https://github.com/ibmdb/node-ibm_db/issues/528#issuecomment-522586377):
> ibm_db@2.6.0 supports node.js v12.x

Tested on CentOS 7.7 that this fix makes it possible to install the plugin in a Node.js 12.x environment.