### PR TITLE
Update Typescript dev dependency to fix @latest build

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/jest": "^20.0.5",
     "@types/node": "^8.0.0",
     "@types/xml2js": "^0.4.3",
-    "@types/yargs": "8.0.2",
+    "@types/yargs": "^8.0.2",
     "@zowe/imperative": "4.1.1",
     "env-cmd": "^8.0.2",
     "fs-extra": "^5.0.0",
@@ -61,7 +61,7 @@
     "ts-node": "^3.2.0",
     "tslint": "^5.0.0",
     "typedoc": "^0.9.0",
-    "typescript": "3.2.2",
+    "typescript": "^3.2.2",
     "uuid": "^3.2.1"
   },
   "jest": {


### PR DESCRIPTION
This fixes the master build, which was failing because the Typescript version in `package.json` was incompatible with the new version used in @zowe/imperative 4.4.8. The fix has been tested in a protected branch.