### PR TITLE
Decrease Imperative load time for plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the IBM® Db2® Plug-in for Zowe CLI will be documented in this file.
 
-## `4.0.6`
+## Recent Changes
 
 - Decrease Imperative load time for plugin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® Db2® Plug-in for Zowe CLI will be documented in this file.
 
+## `4.0.6`
+
+- Decrease Imperative load time for plugin
+
 ## `4.0.5`
 
 - Tagged 4.X.X as @zowe-v1-lts
@@ -12,7 +16,7 @@ All notable changes to the IBM® Db2® Plug-in for Zowe CLI will be documented i
 
 ## `4.0.3`
 
-- Updated documentation to include Xcode, fix links and branding 
+- Updated documentation to include Xcode, fix links and branding
 
 ## `4.0.2`
 

--- a/src/imperative.ts
+++ b/src/imperative.ts
@@ -10,7 +10,7 @@
 */
 
 import { IImperativeConfig } from "@zowe/imperative";
-import { Constants } from "./";
+import { Constants } from "./Constants";
 
 const config: IImperativeConfig = {
     name: Constants.PROD_NAME,


### PR DESCRIPTION
This PR minimizes the number of files that Node must require when Imperative loads the plugin config. On my machine, it decreases the time to load the plugin config from ~500 ms to <10 ms.