### PR TITLE
Add an example for passing outputs from an sp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® Db2® Plug-in for Zowe CLI will be documented in this file.
 
+## `4.0.8` 
+
+- Enhancement: Added a help example for how to pass output values when calling a Db2 stored procedure. 
+
 ## `4.0.7`
 
 - BugFix: Added support for Node v14. [#60](https://github.com/zowe/zowe-cli-db2-plugin/pull/60)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the IBM® Db2® Plug-in for Zowe CLI will be documented in this file.
 
-## `4.0.8` 
+## Recent Changes
 
 - Enhancement: Added a help example for how to pass output values when calling a Db2 stored procedure. 
 

--- a/__tests__/cli/call/procedure/__snapshots__/Procedure.definition.unit.test.ts.snap
+++ b/__tests__/cli/call/procedure/__snapshots__/Procedure.definition.unit.test.ts.snap
@@ -16,6 +16,10 @@ Object {
       "description": "Call a stored procedure and pass values for parameter indicators",
       "options": "\\"DEMO.SP2(?, ?)\\" --parameters \\"Hello\\" \\"world!\\"",
     },
+    Object {
+      "description": "Call a stored procedure and pass values for two output parameters. The first output requires a 2-character buffer. The second output is a message that will be truncated to the length of the placeholder.",
+      "options": "\\"DEMO.SP3(NULL, ?, ?)\\" --parameters \\"00\\" \\"message_placeholder_message_placeholder\\"",
+    },
   ],
   "name": "procedure",
   "options": Array [

--- a/src/cli/call/procedure/Procedure.definition.ts
+++ b/src/cli/call/procedure/Procedure.definition.ts
@@ -50,7 +50,7 @@ export const ProcedureDefinition: ICommandDefinition = {
         },
         {
             description: "Call a stored procedure and pass values for two output parameters. The first output requires a 2-character buffer. The second output is a message that will be truncated to the length of the placeholder.",
-            options: "\"DEMO.SP3(NULL, ?, ?)\" --parameters "00" "message_placeholder_message_placeholder"",
+            options: "\"DEMO.SP3(NULL, ?, ?)\" --parameters \"00\" \"message_placeholder_message_placeholder\"",
         },
     ],
 };

--- a/src/cli/call/procedure/Procedure.definition.ts
+++ b/src/cli/call/procedure/Procedure.definition.ts
@@ -35,7 +35,7 @@ export const ProcedureDefinition: ICommandDefinition = {
             name: "parameters",
             aliases: ["p"],
             type: "array",
-            description: "Values to bind to the stored procedure parameters.",
+            description: "Values to bind to the stored procedure parameters",
             required: false,
         },
     ],

--- a/src/cli/call/procedure/Procedure.definition.ts
+++ b/src/cli/call/procedure/Procedure.definition.ts
@@ -35,7 +35,7 @@ export const ProcedureDefinition: ICommandDefinition = {
             name: "parameters",
             aliases: ["p"],
             type: "array",
-            description: "Values to bind to the stored procedure parameters",
+            description: "Values to bind to the stored procedure parameters.",
             required: false,
         },
     ],
@@ -47,6 +47,10 @@ export const ProcedureDefinition: ICommandDefinition = {
         {
             description: "Call a stored procedure and pass values for parameter indicators",
             options: "\"DEMO.SP2(?, ?)\" --parameters \"Hello\" \"world!\"",
+        },
+        {
+            description: "Call a stored procedure and pass values for two output parameters. The first output requires a 2-character buffer. The second output is a message that will be truncated to the length of the placeholder.",
+            options: "\"DEMO.SP3(NULL, ?, ?)\" --parameters "00" "message_placeholder_message_placeholder"",
         },
     ],
 };


### PR DESCRIPTION
Added example to the `zowe db2 call sp` command.

Q: Is the description too long to display OK in a command line? I think it helps to describe the purpose of the 00 and message_placeholder. Maybe this is obvious to CLI users and doesn't need to be pointed out though. 

Signed-off-by: Brandon Jenkins <36675406+BrandonJenkins14@users.noreply.github.com>