### PR TITLE
Fix daemon mode prompts, snapshots, help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the IBM® Db2® Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fix error messages when host, port, user, password, or database are omitted
+- BugFix: Fix daemon mode prompting
+
 ## `5.0.0-next.202203241624`
 
 - BugFix: Updated follow-redirects and minimist dependencies to resolve potential vulnerabilities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to the IBM® Db2® Plug-in for Zowe CLI will be documented i
 
 ## Recent Changes
 
-- BugFix: Fix error messages when host, port, user, password, or database are omitted
-- BugFix: Fix daemon mode prompting
+- BugFix: Fixed error messages when host, port, user, password, or database are omitted
+- BugFix: Fixed daemon mode prompting
 
 ## `5.0.0-next.202203241624`
 

--- a/__tests__/__system__/cli/call/__snapshots__/cli.db2.call.stored-proc.system.test.ts.snap
+++ b/__tests__/__system__/cli/call/__snapshots__/cli.db2.call.stored-proc.system.test.ts.snap
@@ -28,82 +28,90 @@ exports[`db2 call stored procedure command should display the help 1`] = `
  OPTIONS
  -------
 
-   --parameters  | -p (array)
+   --parameters | -p (array)
 
       Values to bind to the stored procedure parameters
 
  DB2 CONNECTION OPTIONS
  ----------------------
 
-   --host  | -H (string)
+   --host | -H (string)
 
       The Db2 server host name
 
-   --port  | -P (number)
+   --port | -P (number)
 
       The Db2 server port number
 
-   --user  | -u (string)
+   --user | -u (string)
 
       The Db2 user ID (may be the same as the TSO login)
 
-   --password  | --pass | --pw (string)
+   --password | --pass | --pw (string)
 
       The Db2 password (may be the same as the TSO password)
 
-   --database  | --db (string)
+   --database | --db (string)
 
       The name of the database
 
-   --sslFile  | --ssl (string)
+   --sslFile | --ssl (string)
 
       Path to an SSL Certificate file
 
  PROFILE OPTIONS
  ---------------
 
-   --db2-profile  | --db2-p (string)
+   --db2-profile | --db2-p (string)
 
       The name of a (db2) profile to load for this command execution.
 
-   --base-profile  | --base-p (string)
+   --base-profile | --base-p (string)
 
       The name of a (base) profile to load for this command execution.
 
  BASE CONNECTION OPTIONS
  -----------------------
 
-   --reject-unauthorized  | --ru (boolean)
+   --reject-unauthorized | --ru (boolean)
 
       Reject self-signed certificates.
 
       Default value: true
 
-   --token-type  | --tt (string)
+   --token-type | --tt (string)
 
       The type of token to get and use for the API. Omit this option to use the
       default token type, which is provided by 'zowe auth login'.
 
-   --token-value  | --tv (string)
+   --token-value | --tv (string)
 
       The value of the token to pass to the API.
+
+   --cert-file (local file path)
+
+      The file path to a certificate file to use for authentication
+
+   --cert-key-file (local file path)
+
+      The file path to a certificate key file to use for authentication
 
  GLOBAL OPTIONS
  --------------
 
-   --response-format-json  | --rfj (boolean)
+   --response-format-json | --rfj (boolean)
 
       Produce JSON formatted data from a command
 
-   --help  | -h (boolean)
+   --help | -h (boolean)
 
       Display help text
 
-   --help-examples  (boolean)
+   --help-examples (boolean)
 
       Display examples for all the commands in a group
 
-   --help-web  | --hw (boolean)
+   --help-web | --hw (boolean)
 
       Display HTML help in browser
 
@@ -129,8 +137,8 @@ exports[`db2 call stored procedure command should display the help 1`] = `
   \\"success\\": true,
   \\"exitCode\\": 0,
   \\"message\\": \\"The help was constructed for command: procedure.\\",
-  \\"stdout\\": \\"\\\\n COMMAND NAME\\\\n ------------\\\\n\\\\n   procedure | proc | sp\\\\n\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Call a Db2 stored procedure. Specify the stored procedure name and optionally\\\\n   provide values.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 call procedure <routine> [options]\\\\n\\\\n POSITIONAL ARGUMENTS\\\\n --------------------\\\\n\\\\n   routine\\\\t\\\\t (string)\\\\n\\\\n      The name of a Db2 stored procedure\\\\n\\\\n OPTIONS\\\\n -------\\\\n\\\\n   --parameters  | -p (array)\\\\n\\\\n      Values to bind to the stored procedure parameters\\\\n\\\\n DB2 CONNECTION OPTIONS\\\\n ----------------------\\\\n\\\\n   --host  | -H (string)\\\\n\\\\n      The Db2 server host name\\\\n\\\\n   --port  | -P (number)\\\\n\\\\n      The Db2 server port number\\\\n\\\\n   --user  | -u (string)\\\\n\\\\n      The Db2 user ID (may be the same as the TSO login)\\\\n\\\\n   --password  | --pass | --pw (string)\\\\n\\\\n      The Db2 password (may be the same as the TSO password)\\\\n\\\\n   --database  | --db (string)\\\\n\\\\n      The name of the database\\\\n\\\\n   --sslFile  | --ssl (string)\\\\n\\\\n      Path to an SSL Certificate file\\\\n\\\\n PROFILE OPTIONS\\\\n ---------------\\\\n\\\\n   --db2-profile  | --db2-p (string)\\\\n\\\\n      The name of a (db2) profile to load for this command execution.\\\\n\\\\n   --base-profile  | --base-p (string)\\\\n\\\\n      The name of a (base) profile to load for this command execution.\\\\n\\\\n BASE CONNECTION OPTIONS\\\\n -----------------------\\\\n\\\\n   --reject-unauthorized  | --ru (boolean)\\\\n\\\\n      Reject self-signed certificates.\\\\n\\\\n      Default value: true\\\\n\\\\n   --token-type  | --tt (string)\\\\n\\\\n      The type of token to get and use for the API. Omit this option to use the\\\\n      default token type, which is provided by 'zowe auth login'.\\\\n\\\\n   --token-value  | --tv (string)\\\\n\\\\n      The value of the token to pass to the API.\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples  (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web  | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n EXAMPLES\\\\n --------\\\\n\\\\n   - Call stored procedure DEMO.SP1:\\\\n\\\\n      $ zowe db2 call procedure \\\\\\"DEMO.SP1\\\\\\"\\\\n\\\\n   - Call a stored procedure and pass values for parameter\\\\n   indicators:\\\\n\\\\n      $ zowe db2 call procedure \\\\\\"DEMO.SP2(?, ?)\\\\\\" --parameters \\\\\\"Hello\\\\\\" \\\\\\"world!\\\\\\"\\\\n\\\\n   - Call a stored procedure and pass values for two output\\\\n   parameters. The first output requires a 2-character buffer. The second output is\\\\n   a message that will be truncated to the length of the placeholder.:\\\\n\\\\n      $ zowe db2 call procedure \\\\\\"DEMO.SP3(NULL, ?, ?)\\\\\\" --parameters \\\\\\"00\\\\\\" \\\\\\"message_placeholder_message_placeholder\\\\\\"\\\\n\\\\n\\",
+  \\"stdout\\": \\"\\\\n COMMAND NAME\\\\n ------------\\\\n\\\\n   procedure | proc | sp\\\\n\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Call a Db2 stored procedure. Specify the stored procedure name and optionally\\\\n   provide values.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 call procedure <routine> [options]\\\\n\\\\n POSITIONAL ARGUMENTS\\\\n --------------------\\\\n\\\\n   routine\\\\t\\\\t (string)\\\\n\\\\n      The name of a Db2 stored procedure\\\\n\\\\n OPTIONS\\\\n -------\\\\n\\\\n   --parameters | -p (array)\\\\n\\\\n      Values to bind to the stored procedure parameters\\\\n\\\\n DB2 CONNECTION OPTIONS\\\\n ----------------------\\\\n\\\\n   --host | -H (string)\\\\n\\\\n      The Db2 server host name\\\\n\\\\n   --port | -P (number)\\\\n\\\\n      The Db2 server port number\\\\n\\\\n   --user | -u (string)\\\\n\\\\n      The Db2 user ID (may be the same as the TSO login)\\\\n\\\\n   --password | --pass | --pw (string)\\\\n\\\\n      The Db2 password (may be the same as the TSO password)\\\\n\\\\n   --database | --db (string)\\\\n\\\\n      The name of the database\\\\n\\\\n   --sslFile | --ssl (string)\\\\n\\\\n      Path to an SSL Certificate file\\\\n\\\\n PROFILE OPTIONS\\\\n ---------------\\\\n\\\\n   --db2-profile | --db2-p (string)\\\\n\\\\n      The name of a (db2) profile to load for this command execution.\\\\n\\\\n   --base-profile | --base-p (string)\\\\n\\\\n      The name of a (base) profile to load for this command execution.\\\\n\\\\n BASE CONNECTION OPTIONS\\\\n -----------------------\\\\n\\\\n   --reject-unauthorized | --ru (boolean)\\\\n\\\\n      Reject self-signed certificates.\\\\n\\\\n      Default value: true\\\\n\\\\n   --token-type | --tt (string)\\\\n\\\\n      The type of token to get and use for the API. Omit this option to use the\\\\n      default token type, which is provided by 'zowe auth login'.\\\\n\\\\n   --token-value | --tv (string)\\\\n\\\\n      The value of the token to pass to the API.\\\\n\\\\n   --cert-file (local file path)\\\\n\\\\n      The file path to a certificate file to use for authentication\\\\n\\\\n   --cert-key-file (local file path)\\\\n\\\\n      The file path to a certificate key file to use for authentication\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n EXAMPLES\\\\n --------\\\\n\\\\n   - Call stored procedure DEMO.SP1:\\\\n\\\\n      $ zowe db2 call procedure \\\\\\"DEMO.SP1\\\\\\"\\\\n\\\\n   - Call a stored procedure and pass values for parameter\\\\n   indicators:\\\\n\\\\n      $ zowe db2 call procedure \\\\\\"DEMO.SP2(?, ?)\\\\\\" --parameters \\\\\\"Hello\\\\\\" \\\\\\"world!\\\\\\"\\\\n\\\\n   - Call a stored procedure and pass values for two output\\\\n   parameters. The first output requires a 2-character buffer. The second output is\\\\n   a message that will be truncated to the length of the placeholder.:\\\\n\\\\n      $ zowe db2 call procedure \\\\\\"DEMO.SP3(NULL, ?, ?)\\\\\\" --parameters \\\\\\"00\\\\\\" \\\\\\"message_placeholder_message_placeholder\\\\\\"\\\\n\\\\n\\",
   \\"stderr\\": \\"\\",
-  \\"data\\": \\"\\\\n COMMAND NAME\\\\n ------------\\\\n\\\\n   procedure | proc | sp\\\\n\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Call a Db2 stored procedure. Specify the stored procedure name and optionally\\\\n   provide values.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 call procedure <routine> [options]\\\\n\\\\n POSITIONAL ARGUMENTS\\\\n --------------------\\\\n\\\\n   routine\\\\t\\\\t (string)\\\\n\\\\n      The name of a Db2 stored procedure\\\\n\\\\n OPTIONS\\\\n -------\\\\n\\\\n   --parameters  | -p (array)\\\\n\\\\n      Values to bind to the stored procedure parameters\\\\n\\\\n DB2 CONNECTION OPTIONS\\\\n ----------------------\\\\n\\\\n   --host  | -H (string)\\\\n\\\\n      The Db2 server host name\\\\n\\\\n   --port  | -P (number)\\\\n\\\\n      The Db2 server port number\\\\n\\\\n   --user  | -u (string)\\\\n\\\\n      The Db2 user ID (may be the same as the TSO login)\\\\n\\\\n   --password  | --pass | --pw (string)\\\\n\\\\n      The Db2 password (may be the same as the TSO password)\\\\n\\\\n   --database  | --db (string)\\\\n\\\\n      The name of the database\\\\n\\\\n   --sslFile  | --ssl (string)\\\\n\\\\n      Path to an SSL Certificate file\\\\n\\\\n PROFILE OPTIONS\\\\n ---------------\\\\n\\\\n   --db2-profile  | --db2-p (string)\\\\n\\\\n      The name of a (db2) profile to load for this command execution.\\\\n\\\\n   --base-profile  | --base-p (string)\\\\n\\\\n      The name of a (base) profile to load for this command execution.\\\\n\\\\n BASE CONNECTION OPTIONS\\\\n -----------------------\\\\n\\\\n   --reject-unauthorized  | --ru (boolean)\\\\n\\\\n      Reject self-signed certificates.\\\\n\\\\n      Default value: true\\\\n\\\\n   --token-type  | --tt (string)\\\\n\\\\n      The type of token to get and use for the API. Omit this option to use the\\\\n      default token type, which is provided by 'zowe auth login'.\\\\n\\\\n   --token-value  | --tv (string)\\\\n\\\\n      The value of the token to pass to the API.\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples  (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web  | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n EXAMPLES\\\\n --------\\\\n\\\\n   - Call stored procedure DEMO.SP1:\\\\n\\\\n      $ zowe db2 call procedure \\\\\\"DEMO.SP1\\\\\\"\\\\n\\\\n   - Call a stored procedure and pass values for parameter\\\\n   indicators:\\\\n\\\\n      $ zowe db2 call procedure \\\\\\"DEMO.SP2(?, ?)\\\\\\" --parameters \\\\\\"Hello\\\\\\" \\\\\\"world!\\\\\\"\\\\n\\\\n   - Call a stored procedure and pass values for two output\\\\n   parameters. The first output requires a 2-character buffer. The second output is\\\\n   a message that will be truncated to the length of the placeholder.:\\\\n\\\\n      $ zowe db2 call procedure \\\\\\"DEMO.SP3(NULL, ?, ?)\\\\\\" --parameters \\\\\\"00\\\\\\" \\\\\\"message_placeholder_message_placeholder\\\\\\"\\\\n\\\\n\\"
+  \\"data\\": \\"\\\\n COMMAND NAME\\\\n ------------\\\\n\\\\n   procedure | proc | sp\\\\n\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Call a Db2 stored procedure. Specify the stored procedure name and optionally\\\\n   provide values.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 call procedure <routine> [options]\\\\n\\\\n POSITIONAL ARGUMENTS\\\\n --------------------\\\\n\\\\n   routine\\\\t\\\\t (string)\\\\n\\\\n      The name of a Db2 stored procedure\\\\n\\\\n OPTIONS\\\\n -------\\\\n\\\\n   --parameters | -p (array)\\\\n\\\\n      Values to bind to the stored procedure parameters\\\\n\\\\n DB2 CONNECTION OPTIONS\\\\n ----------------------\\\\n\\\\n   --host | -H (string)\\\\n\\\\n      The Db2 server host name\\\\n\\\\n   --port | -P (number)\\\\n\\\\n      The Db2 server port number\\\\n\\\\n   --user | -u (string)\\\\n\\\\n      The Db2 user ID (may be the same as the TSO login)\\\\n\\\\n   --password | --pass | --pw (string)\\\\n\\\\n      The Db2 password (may be the same as the TSO password)\\\\n\\\\n   --database | --db (string)\\\\n\\\\n      The name of the database\\\\n\\\\n   --sslFile | --ssl (string)\\\\n\\\\n      Path to an SSL Certificate file\\\\n\\\\n PROFILE OPTIONS\\\\n ---------------\\\\n\\\\n   --db2-profile | --db2-p (string)\\\\n\\\\n      The name of a (db2) profile to load for this command execution.\\\\n\\\\n   --base-profile | --base-p (string)\\\\n\\\\n      The name of a (base) profile to load for this command execution.\\\\n\\\\n BASE CONNECTION OPTIONS\\\\n -----------------------\\\\n\\\\n   --reject-unauthorized | --ru (boolean)\\\\n\\\\n      Reject self-signed certificates.\\\\n\\\\n      Default value: true\\\\n\\\\n   --token-type | --tt (string)\\\\n\\\\n      The type of token to get and use for the API. Omit this option to use the\\\\n      default token type, which is provided by 'zowe auth login'.\\\\n\\\\n   --token-value | --tv (string)\\\\n\\\\n      The value of the token to pass to the API.\\\\n\\\\n   --cert-file (local file path)\\\\n\\\\n      The file path to a certificate file to use for authentication\\\\n\\\\n   --cert-key-file (local file path)\\\\n\\\\n      The file path to a certificate key file to use for authentication\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n EXAMPLES\\\\n --------\\\\n\\\\n   - Call stored procedure DEMO.SP1:\\\\n\\\\n      $ zowe db2 call procedure \\\\\\"DEMO.SP1\\\\\\"\\\\n\\\\n   - Call a stored procedure and pass values for parameter\\\\n   indicators:\\\\n\\\\n      $ zowe db2 call procedure \\\\\\"DEMO.SP2(?, ?)\\\\\\" --parameters \\\\\\"Hello\\\\\\" \\\\\\"world!\\\\\\"\\\\n\\\\n   - Call a stored procedure and pass values for two output\\\\n   parameters. The first output requires a 2-character buffer. The second output is\\\\n   a message that will be truncated to the length of the placeholder.:\\\\n\\\\n      $ zowe db2 call procedure \\\\\\"DEMO.SP3(NULL, ?, ?)\\\\\\" --parameters \\\\\\"00\\\\\\" \\\\\\"message_placeholder_message_placeholder\\\\\\"\\\\n\\\\n\\"
 }"
 `;

--- a/__tests__/__system__/cli/call/__snapshots__/cli.db2.call.system.test.ts.snap
+++ b/__tests__/__system__/cli/call/__snapshots__/cli.db2.call.system.test.ts.snap
@@ -22,19 +22,19 @@ exports[`db2 call command should display the help 1`] = `
  GLOBAL OPTIONS
  --------------
 
-   --response-format-json  | --rfj (boolean)
+   --response-format-json | --rfj (boolean)
 
       Produce JSON formatted data from a command
 
-   --help  | -h (boolean)
+   --help | -h (boolean)
 
       Display help text
 
-   --help-examples  (boolean)
+   --help-examples (boolean)
 
       Display examples for all the commands in a group
 
-   --help-web  | --hw (boolean)
+   --help-web | --hw (boolean)
 
       Display HTML help in browser
 
@@ -42,9 +42,9 @@ exports[`db2 call command should display the help 1`] = `
   \\"success\\": true,
   \\"exitCode\\": 0,
   \\"message\\": \\"The help was constructed for command: call.\\",
-  \\"stdout\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Call a Db2 stored procedure\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 call <command>\\\\n\\\\n   Where <command> is one of the following:\\\\n\\\\n COMMANDS\\\\n --------\\\\n\\\\n   procedure | proc | sp Call a Db2 stored procedure\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples  (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web  | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n\\",
+  \\"stdout\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Call a Db2 stored procedure\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 call <command>\\\\n\\\\n   Where <command> is one of the following:\\\\n\\\\n COMMANDS\\\\n --------\\\\n\\\\n   procedure | proc | sp Call a Db2 stored procedure\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n\\",
   \\"stderr\\": \\"\\",
-  \\"data\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Call a Db2 stored procedure\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 call <command>\\\\n\\\\n   Where <command> is one of the following:\\\\n\\\\n COMMANDS\\\\n --------\\\\n\\\\n   procedure | proc | sp Call a Db2 stored procedure\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples  (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web  | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n\\"
+  \\"data\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Call a Db2 stored procedure\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 call <command>\\\\n\\\\n   Where <command> is one of the following:\\\\n\\\\n COMMANDS\\\\n --------\\\\n\\\\n   procedure | proc | sp Call a Db2 stored procedure\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n\\"
 }"
 `;
 
@@ -52,7 +52,9 @@ exports[`db2 call command should fail with invalid option 1`] = `
 "Command Error:
 Unknown argument: sp
 Command failed due to improper syntax
-Command entered: \\"zowe db2 call --sp DEMOUSER.DEMOSP1(1, 2, 3)\\"
+Did you mean: db2 call sp?
+
+Command entered: \\"db2 call --sp DEMOUSER.DEMOSP1(1, 2, 3)\\"
 Available commands are \\"procedure\\".
 Use \\"zowe db2 call --help\\" to view groups, commands, and options.
 Error Details:
@@ -66,7 +68,9 @@ exports[`db2 call command should fail with invalid parameter 1`] = `
 "Command Error:
 Unknown arguments: routine, DEMOUSER.DEMOSP1
 Command failed due to improper syntax
-Command entered: \\"zowe db2 call routine DEMOUSER.DEMOSP1\\"
+Did you mean: db2 call proc?
+
+Command entered: \\"db2 call routine DEMOUSER.DEMOSP1\\"
 Available commands are \\"procedure\\".
 Use \\"zowe db2 call --help\\" to view groups, commands, and options.
 Error Details:

--- a/__tests__/__system__/cli/execute/__snapshots__/cli.db2.execute.sql.system.test.ts.snap
+++ b/__tests__/__system__/cli/execute/__snapshots__/cli.db2.execute.sql.system.test.ts.snap
@@ -61,86 +61,94 @@ exports[`db2 execute sql command should display the help 1`] = `
  OPTIONS
  -------
 
-   --query  | -q (string)
+   --query | -q (string)
 
       The SQL statement verbatim to execute
 
-   --file  | -f (string)
+   --file | -f (string)
 
       A local file containing the SQL statements to execute
 
  DB2 CONNECTION OPTIONS
  ----------------------
 
-   --host  | -H (string)
+   --host | -H (string)
 
       The Db2 server host name
 
-   --port  | -P (number)
+   --port | -P (number)
 
       The Db2 server port number
 
-   --user  | -u (string)
+   --user | -u (string)
 
       The Db2 user ID (may be the same as the TSO login)
 
-   --password  | --pass | --pw (string)
+   --password | --pass | --pw (string)
 
       The Db2 password (may be the same as the TSO password)
 
-   --database  | --db (string)
+   --database | --db (string)
 
       The name of the database
 
-   --sslFile  | --ssl (string)
+   --sslFile | --ssl (string)
 
       Path to an SSL Certificate file
 
  PROFILE OPTIONS
  ---------------
 
-   --db2-profile  | --db2-p (string)
+   --db2-profile | --db2-p (string)
 
       The name of a (db2) profile to load for this command execution.
 
-   --base-profile  | --base-p (string)
+   --base-profile | --base-p (string)
 
       The name of a (base) profile to load for this command execution.
 
  BASE CONNECTION OPTIONS
  -----------------------
 
-   --reject-unauthorized  | --ru (boolean)
+   --reject-unauthorized | --ru (boolean)
 
       Reject self-signed certificates.
 
       Default value: true
 
-   --token-type  | --tt (string)
+   --token-type | --tt (string)
 
       The type of token to get and use for the API. Omit this option to use the
       default token type, which is provided by 'zowe auth login'.
 
-   --token-value  | --tv (string)
+   --token-value | --tv (string)
 
       The value of the token to pass to the API.
+
+   --cert-file (local file path)
+
+      The file path to a certificate file to use for authentication
+
+   --cert-key-file (local file path)
+
+      The file path to a certificate key file to use for authentication
 
  GLOBAL OPTIONS
  --------------
 
-   --response-format-json  | --rfj (boolean)
+   --response-format-json | --rfj (boolean)
 
       Produce JSON formatted data from a command
 
-   --help  | -h (boolean)
+   --help | -h (boolean)
 
       Display help text
 
-   --help-examples  (boolean)
+   --help-examples (boolean)
 
       Display examples for all the commands in a group
 
-   --help-web  | --hw (boolean)
+   --help-web | --hw (boolean)
 
       Display HTML help in browser
 
@@ -163,9 +171,9 @@ exports[`db2 execute sql command should display the help 1`] = `
   \\"success\\": true,
   \\"exitCode\\": 0,
   \\"message\\": \\"The help was constructed for command: sql.\\",
-  \\"stdout\\": \\"\\\\n COMMAND NAME\\\\n ------------\\\\n\\\\n   sql\\\\n\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Execute one or multiple SQL statements separated by a semicolon from a command\\\\n   line or from a file.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 execute sql [options]\\\\n\\\\n OPTIONS\\\\n -------\\\\n\\\\n   --query  | -q (string)\\\\n\\\\n      The SQL statement verbatim to execute\\\\n\\\\n   --file  | -f (string)\\\\n\\\\n      A local file containing the SQL statements to execute\\\\n\\\\n DB2 CONNECTION OPTIONS\\\\n ----------------------\\\\n\\\\n   --host  | -H (string)\\\\n\\\\n      The Db2 server host name\\\\n\\\\n   --port  | -P (number)\\\\n\\\\n      The Db2 server port number\\\\n\\\\n   --user  | -u (string)\\\\n\\\\n      The Db2 user ID (may be the same as the TSO login)\\\\n\\\\n   --password  | --pass | --pw (string)\\\\n\\\\n      The Db2 password (may be the same as the TSO password)\\\\n\\\\n   --database  | --db (string)\\\\n\\\\n      The name of the database\\\\n\\\\n   --sslFile  | --ssl (string)\\\\n\\\\n      Path to an SSL Certificate file\\\\n\\\\n PROFILE OPTIONS\\\\n ---------------\\\\n\\\\n   --db2-profile  | --db2-p (string)\\\\n\\\\n      The name of a (db2) profile to load for this command execution.\\\\n\\\\n   --base-profile  | --base-p (string)\\\\n\\\\n      The name of a (base) profile to load for this command execution.\\\\n\\\\n BASE CONNECTION OPTIONS\\\\n -----------------------\\\\n\\\\n   --reject-unauthorized  | --ru (boolean)\\\\n\\\\n      Reject self-signed certificates.\\\\n\\\\n      Default value: true\\\\n\\\\n   --token-type  | --tt (string)\\\\n\\\\n      The type of token to get and use for the API. Omit this option to use the\\\\n      default token type, which is provided by 'zowe auth login'.\\\\n\\\\n   --token-value  | --tv (string)\\\\n\\\\n      The value of the token to pass to the API.\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples  (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web  | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n EXAMPLES\\\\n --------\\\\n\\\\n   - Execute a dummy SQL query:\\\\n\\\\n      $ zowe db2 execute sql --query \\\\\\"SELECT 'Hello World' FROM SYSIBM.SYSDUMMY1\\\\\\"\\\\n\\\\n   - Retrieve the employees table and total number of rows:\\\\n\\\\n      $ zowe db2 execute sql -q \\\\\\"SELECT * FROM SAMPLE.EMP; SELECT COUNT(*) AS TOTAL FROM SAMPLE.EMP\\\\\\"\\\\n\\\\n   - Execute a file with SQL statements:\\\\n\\\\n      $ zowe db2 execute sql --file backup_sample_database.sql\\\\n\\\\n\\",
+  \\"stdout\\": \\"\\\\n COMMAND NAME\\\\n ------------\\\\n\\\\n   sql\\\\n\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Execute one or multiple SQL statements separated by a semicolon from a command\\\\n   line or from a file.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 execute sql [options]\\\\n\\\\n OPTIONS\\\\n -------\\\\n\\\\n   --query | -q (string)\\\\n\\\\n      The SQL statement verbatim to execute\\\\n\\\\n   --file | -f (string)\\\\n\\\\n      A local file containing the SQL statements to execute\\\\n\\\\n DB2 CONNECTION OPTIONS\\\\n ----------------------\\\\n\\\\n   --host | -H (string)\\\\n\\\\n      The Db2 server host name\\\\n\\\\n   --port | -P (number)\\\\n\\\\n      The Db2 server port number\\\\n\\\\n   --user | -u (string)\\\\n\\\\n      The Db2 user ID (may be the same as the TSO login)\\\\n\\\\n   --password | --pass | --pw (string)\\\\n\\\\n      The Db2 password (may be the same as the TSO password)\\\\n\\\\n   --database | --db (string)\\\\n\\\\n      The name of the database\\\\n\\\\n   --sslFile | --ssl (string)\\\\n\\\\n      Path to an SSL Certificate file\\\\n\\\\n PROFILE OPTIONS\\\\n ---------------\\\\n\\\\n   --db2-profile | --db2-p (string)\\\\n\\\\n      The name of a (db2) profile to load for this command execution.\\\\n\\\\n   --base-profile | --base-p (string)\\\\n\\\\n      The name of a (base) profile to load for this command execution.\\\\n\\\\n BASE CONNECTION OPTIONS\\\\n -----------------------\\\\n\\\\n   --reject-unauthorized | --ru (boolean)\\\\n\\\\n      Reject self-signed certificates.\\\\n\\\\n      Default value: true\\\\n\\\\n   --token-type | --tt (string)\\\\n\\\\n      The type of token to get and use for the API. Omit this option to use the\\\\n      default token type, which is provided by 'zowe auth login'.\\\\n\\\\n   --token-value | --tv (string)\\\\n\\\\n      The value of the token to pass to the API.\\\\n\\\\n   --cert-file (local file path)\\\\n\\\\n      The file path to a certificate file to use for authentication\\\\n\\\\n   --cert-key-file (local file path)\\\\n\\\\n      The file path to a certificate key file to use for authentication\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n EXAMPLES\\\\n --------\\\\n\\\\n   - Execute a dummy SQL query:\\\\n\\\\n      $ zowe db2 execute sql --query \\\\\\"SELECT 'Hello World' FROM SYSIBM.SYSDUMMY1\\\\\\"\\\\n\\\\n   - Retrieve the employees table and total number of rows:\\\\n\\\\n      $ zowe db2 execute sql -q \\\\\\"SELECT * FROM SAMPLE.EMP; SELECT COUNT(*) AS TOTAL FROM SAMPLE.EMP\\\\\\"\\\\n\\\\n   - Execute a file with SQL statements:\\\\n\\\\n      $ zowe db2 execute sql --file backup_sample_database.sql\\\\n\\\\n\\",
   \\"stderr\\": \\"\\",
-  \\"data\\": \\"\\\\n COMMAND NAME\\\\n ------------\\\\n\\\\n   sql\\\\n\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Execute one or multiple SQL statements separated by a semicolon from a command\\\\n   line or from a file.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 execute sql [options]\\\\n\\\\n OPTIONS\\\\n -------\\\\n\\\\n   --query  | -q (string)\\\\n\\\\n      The SQL statement verbatim to execute\\\\n\\\\n   --file  | -f (string)\\\\n\\\\n      A local file containing the SQL statements to execute\\\\n\\\\n DB2 CONNECTION OPTIONS\\\\n ----------------------\\\\n\\\\n   --host  | -H (string)\\\\n\\\\n      The Db2 server host name\\\\n\\\\n   --port  | -P (number)\\\\n\\\\n      The Db2 server port number\\\\n\\\\n   --user  | -u (string)\\\\n\\\\n      The Db2 user ID (may be the same as the TSO login)\\\\n\\\\n   --password  | --pass | --pw (string)\\\\n\\\\n      The Db2 password (may be the same as the TSO password)\\\\n\\\\n   --database  | --db (string)\\\\n\\\\n      The name of the database\\\\n\\\\n   --sslFile  | --ssl (string)\\\\n\\\\n      Path to an SSL Certificate file\\\\n\\\\n PROFILE OPTIONS\\\\n ---------------\\\\n\\\\n   --db2-profile  | --db2-p (string)\\\\n\\\\n      The name of a (db2) profile to load for this command execution.\\\\n\\\\n   --base-profile  | --base-p (string)\\\\n\\\\n      The name of a (base) profile to load for this command execution.\\\\n\\\\n BASE CONNECTION OPTIONS\\\\n -----------------------\\\\n\\\\n   --reject-unauthorized  | --ru (boolean)\\\\n\\\\n      Reject self-signed certificates.\\\\n\\\\n      Default value: true\\\\n\\\\n   --token-type  | --tt (string)\\\\n\\\\n      The type of token to get and use for the API. Omit this option to use the\\\\n      default token type, which is provided by 'zowe auth login'.\\\\n\\\\n   --token-value  | --tv (string)\\\\n\\\\n      The value of the token to pass to the API.\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples  (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web  | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n EXAMPLES\\\\n --------\\\\n\\\\n   - Execute a dummy SQL query:\\\\n\\\\n      $ zowe db2 execute sql --query \\\\\\"SELECT 'Hello World' FROM SYSIBM.SYSDUMMY1\\\\\\"\\\\n\\\\n   - Retrieve the employees table and total number of rows:\\\\n\\\\n      $ zowe db2 execute sql -q \\\\\\"SELECT * FROM SAMPLE.EMP; SELECT COUNT(*) AS TOTAL FROM SAMPLE.EMP\\\\\\"\\\\n\\\\n   - Execute a file with SQL statements:\\\\n\\\\n      $ zowe db2 execute sql --file backup_sample_database.sql\\\\n\\\\n\\"
+  \\"data\\": \\"\\\\n COMMAND NAME\\\\n ------------\\\\n\\\\n   sql\\\\n\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Execute one or multiple SQL statements separated by a semicolon from a command\\\\n   line or from a file.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 execute sql [options]\\\\n\\\\n OPTIONS\\\\n -------\\\\n\\\\n   --query | -q (string)\\\\n\\\\n      The SQL statement verbatim to execute\\\\n\\\\n   --file | -f (string)\\\\n\\\\n      A local file containing the SQL statements to execute\\\\n\\\\n DB2 CONNECTION OPTIONS\\\\n ----------------------\\\\n\\\\n   --host | -H (string)\\\\n\\\\n      The Db2 server host name\\\\n\\\\n   --port | -P (number)\\\\n\\\\n      The Db2 server port number\\\\n\\\\n   --user | -u (string)\\\\n\\\\n      The Db2 user ID (may be the same as the TSO login)\\\\n\\\\n   --password | --pass | --pw (string)\\\\n\\\\n      The Db2 password (may be the same as the TSO password)\\\\n\\\\n   --database | --db (string)\\\\n\\\\n      The name of the database\\\\n\\\\n   --sslFile | --ssl (string)\\\\n\\\\n      Path to an SSL Certificate file\\\\n\\\\n PROFILE OPTIONS\\\\n ---------------\\\\n\\\\n   --db2-profile | --db2-p (string)\\\\n\\\\n      The name of a (db2) profile to load for this command execution.\\\\n\\\\n   --base-profile | --base-p (string)\\\\n\\\\n      The name of a (base) profile to load for this command execution.\\\\n\\\\n BASE CONNECTION OPTIONS\\\\n -----------------------\\\\n\\\\n   --reject-unauthorized | --ru (boolean)\\\\n\\\\n      Reject self-signed certificates.\\\\n\\\\n      Default value: true\\\\n\\\\n   --token-type | --tt (string)\\\\n\\\\n      The type of token to get and use for the API. Omit this option to use the\\\\n      default token type, which is provided by 'zowe auth login'.\\\\n\\\\n   --token-value | --tv (string)\\\\n\\\\n      The value of the token to pass to the API.\\\\n\\\\n   --cert-file (local file path)\\\\n\\\\n      The file path to a certificate file to use for authentication\\\\n\\\\n   --cert-key-file (local file path)\\\\n\\\\n      The file path to a certificate key file to use for authentication\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n EXAMPLES\\\\n --------\\\\n\\\\n   - Execute a dummy SQL query:\\\\n\\\\n      $ zowe db2 execute sql --query \\\\\\"SELECT 'Hello World' FROM SYSIBM.SYSDUMMY1\\\\\\"\\\\n\\\\n   - Retrieve the employees table and total number of rows:\\\\n\\\\n      $ zowe db2 execute sql -q \\\\\\"SELECT * FROM SAMPLE.EMP; SELECT COUNT(*) AS TOTAL FROM SAMPLE.EMP\\\\\\"\\\\n\\\\n   - Execute a file with SQL statements:\\\\n\\\\n      $ zowe db2 execute sql --file backup_sample_database.sql\\\\n\\\\n\\"
 }"
 `;
 
@@ -179,7 +187,7 @@ exports[`db2 execute sql command should fail with invalid option 1`] = `
 "Command Error:
 Unknown argument: commit
 Command failed due to improper syntax
-Command entered: \\"zowe db2 execute sql --commit SELECT 1 FROM SYSIBM.SYSDUMMY1\\"
+Command entered: \\"db2 execute sql --commit SELECT 1 FROM SYSIBM.SYSDUMMY1\\"
 Available commands are \\"sql\\".
 Use \\"zowe db2 execute --help\\" to view groups, commands, and options.
 Error Details:

--- a/__tests__/__system__/cli/execute/__snapshots__/cli.db2.execute.system.test.ts.snap
+++ b/__tests__/__system__/cli/execute/__snapshots__/cli.db2.execute.system.test.ts.snap
@@ -23,19 +23,19 @@ exports[`db2 execute command should display the help 1`] = `
  GLOBAL OPTIONS
  --------------
 
-   --response-format-json  | --rfj (boolean)
+   --response-format-json | --rfj (boolean)
 
       Produce JSON formatted data from a command
 
-   --help  | -h (boolean)
+   --help | -h (boolean)
 
       Display help text
 
-   --help-examples  (boolean)
+   --help-examples (boolean)
 
       Display examples for all the commands in a group
 
-   --help-web  | --hw (boolean)
+   --help-web | --hw (boolean)
 
       Display HTML help in browser
 
@@ -43,9 +43,9 @@ exports[`db2 execute command should display the help 1`] = `
   \\"success\\": true,
   \\"exitCode\\": 0,
   \\"message\\": \\"The help was constructed for command: execute.\\",
-  \\"stdout\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Execute SQL queries against a Db2 region and retrieve the response. Enclose the\\\\n   query in quotes and escape any symbols that have a special meaning to the shell.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 execute <command>\\\\n\\\\n   Where <command> is one of the following:\\\\n\\\\n COMMANDS\\\\n --------\\\\n\\\\n   sql Execute SQL statement\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples  (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web  | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n\\",
+  \\"stdout\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Execute SQL queries against a Db2 region and retrieve the response. Enclose the\\\\n   query in quotes and escape any symbols that have a special meaning to the shell.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 execute <command>\\\\n\\\\n   Where <command> is one of the following:\\\\n\\\\n COMMANDS\\\\n --------\\\\n\\\\n   sql Execute SQL statement\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n\\",
   \\"stderr\\": \\"\\",
-  \\"data\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Execute SQL queries against a Db2 region and retrieve the response. Enclose the\\\\n   query in quotes and escape any symbols that have a special meaning to the shell.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 execute <command>\\\\n\\\\n   Where <command> is one of the following:\\\\n\\\\n COMMANDS\\\\n --------\\\\n\\\\n   sql Execute SQL statement\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples  (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web  | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n\\"
+  \\"data\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Execute SQL queries against a Db2 region and retrieve the response. Enclose the\\\\n   query in quotes and escape any symbols that have a special meaning to the shell.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 execute <command>\\\\n\\\\n   Where <command> is one of the following:\\\\n\\\\n COMMANDS\\\\n --------\\\\n\\\\n   sql Execute SQL statement\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n\\"
 }"
 `;
 
@@ -53,7 +53,9 @@ exports[`db2 execute command should fail with invalid option 1`] = `
 "Command Error:
 Unknown argument: sql
 Command failed due to improper syntax
-Command entered: \\"zowe db2 execute --sql SELECT 1 FROM SYSIBM.SYSDUMMY1\\"
+Did you mean: db2 execute sql?
+
+Command entered: \\"db2 execute --sql SELECT 1 FROM SYSIBM.SYSDUMMY1\\"
 Available commands are \\"sql\\".
 Use \\"zowe db2 execute --help\\" to view groups, commands, and options.
 Error Details:
@@ -67,7 +69,9 @@ exports[`db2 execute command should fail with invalid parameter 1`] = `
 "Command Error:
 Unknown arguments: D, command
 Command failed due to improper syntax
-Command entered: \\"zowe db2 execute command -D DDF\\"
+Did you mean: db2 execute sql?
+
+Command entered: \\"db2 execute command -D DDF\\"
 Available commands are \\"sql\\".
 Use \\"zowe db2 execute --help\\" to view groups, commands, and options.
 Error Details:

--- a/__tests__/__system__/cli/export/__snapshots__/cli.db2.export.system.test.ts.snap
+++ b/__tests__/__system__/cli/export/__snapshots__/cli.db2.export.system.test.ts.snap
@@ -22,19 +22,19 @@ exports[`db2 export command should display the help 1`] = `
  GLOBAL OPTIONS
  --------------
 
-   --response-format-json  | --rfj (boolean)
+   --response-format-json | --rfj (boolean)
 
       Produce JSON formatted data from a command
 
-   --help  | -h (boolean)
+   --help | -h (boolean)
 
       Display help text
 
-   --help-examples  (boolean)
+   --help-examples (boolean)
 
       Display examples for all the commands in a group
 
-   --help-web  | --hw (boolean)
+   --help-web | --hw (boolean)
 
       Display HTML help in browser
 
@@ -42,9 +42,9 @@ exports[`db2 export command should display the help 1`] = `
   \\"success\\": true,
   \\"exitCode\\": 0,
   \\"message\\": \\"The help was constructed for command: export.\\",
-  \\"stdout\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Export data from a Db2 table\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 export <command>\\\\n\\\\n   Where <command> is one of the following:\\\\n\\\\n COMMANDS\\\\n --------\\\\n\\\\n   table Export data from a Db2 table in SQL format\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples  (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web  | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n\\",
+  \\"stdout\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Export data from a Db2 table\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 export <command>\\\\n\\\\n   Where <command> is one of the following:\\\\n\\\\n COMMANDS\\\\n --------\\\\n\\\\n   table Export data from a Db2 table in SQL format\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n\\",
   \\"stderr\\": \\"\\",
-  \\"data\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Export data from a Db2 table\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 export <command>\\\\n\\\\n   Where <command> is one of the following:\\\\n\\\\n COMMANDS\\\\n --------\\\\n\\\\n   table Export data from a Db2 table in SQL format\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples  (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web  | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n\\"
+  \\"data\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Export data from a Db2 table\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 export <command>\\\\n\\\\n   Where <command> is one of the following:\\\\n\\\\n COMMANDS\\\\n --------\\\\n\\\\n   table Export data from a Db2 table in SQL format\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n\\"
 }"
 `;
 
@@ -52,7 +52,9 @@ exports[`db2 export command should fail with invalid option 1`] = `
 "Command Error:
 Unknown argument: table
 Command failed due to improper syntax
-Command entered: \\"zowe db2 export --table SYSIBM.SYSDUMMY1\\"
+Did you mean: db2 export table?
+
+Command entered: \\"db2 export --table SYSIBM.SYSDUMMY1\\"
 Available commands are \\"table\\".
 Use \\"zowe db2 export --help\\" to view groups, commands, and options.
 Error Details:
@@ -66,7 +68,9 @@ exports[`db2 export command should fail with invalid parameter 1`] = `
 "Command Error:
 Unknown arguments: schema, DEMOUSER.DEMOTABLE
 Command failed due to improper syntax
-Command entered: \\"zowe db2 export schema DEMOUSER.DEMOTABLE\\"
+Did you mean: db2 export table?
+
+Command entered: \\"db2 export schema DEMOUSER.DEMOTABLE\\"
 Available commands are \\"table\\".
 Use \\"zowe db2 export --help\\" to view groups, commands, and options.
 Error Details:

--- a/__tests__/__system__/cli/export/__snapshots__/cli.db2.export.table.system.test.ts.snap
+++ b/__tests__/__system__/cli/export/__snapshots__/cli.db2.export.table.system.test.ts.snap
@@ -27,86 +27,94 @@ exports[`db2 export table command should display the help 1`] = `
  OPTIONS
  -------
 
-   --outfile  | -o (string)
+   --outfile | -o (string)
 
       The path to the output file
 
-   --separator  | --sep (string)
+   --separator | --sep (string)
 
       Specify whether to add a separator between statements when exporting a table
 
  DB2 CONNECTION OPTIONS
  ----------------------
 
-   --host  | -H (string)
+   --host | -H (string)
 
       The Db2 server host name
 
-   --port  | -P (number)
+   --port | -P (number)
 
       The Db2 server port number
 
-   --user  | -u (string)
+   --user | -u (string)
 
       The Db2 user ID (may be the same as the TSO login)
 
-   --password  | --pass | --pw (string)
+   --password | --pass | --pw (string)
 
       The Db2 password (may be the same as the TSO password)
 
-   --database  | --db (string)
+   --database | --db (string)
 
       The name of the database
 
-   --sslFile  | --ssl (string)
+   --sslFile | --ssl (string)
 
       Path to an SSL Certificate file
 
  PROFILE OPTIONS
  ---------------
 
-   --db2-profile  | --db2-p (string)
+   --db2-profile | --db2-p (string)
 
       The name of a (db2) profile to load for this command execution.
 
-   --base-profile  | --base-p (string)
+   --base-profile | --base-p (string)
 
       The name of a (base) profile to load for this command execution.
 
  BASE CONNECTION OPTIONS
  -----------------------
 
-   --reject-unauthorized  | --ru (boolean)
+   --reject-unauthorized | --ru (boolean)
 
       Reject self-signed certificates.
 
       Default value: true
 
-   --token-type  | --tt (string)
+   --token-type | --tt (string)
 
       The type of token to get and use for the API. Omit this option to use the
       default token type, which is provided by 'zowe auth login'.
 
-   --token-value  | --tv (string)
+   --token-value | --tv (string)
 
       The value of the token to pass to the API.
+
+   --cert-file (local file path)
+
+      The file path to a certificate file to use for authentication
+
+   --cert-key-file (local file path)
+
+      The file path to a certificate key file to use for authentication
 
  GLOBAL OPTIONS
  --------------
 
-   --response-format-json  | --rfj (boolean)
+   --response-format-json | --rfj (boolean)
 
       Produce JSON formatted data from a command
 
-   --help  | -h (boolean)
+   --help | -h (boolean)
 
       Display help text
 
-   --help-examples  (boolean)
+   --help-examples (boolean)
 
       Display examples for all the commands in a group
 
-   --help-web  | --hw (boolean)
+   --help-web | --hw (boolean)
 
       Display HTML help in browser
 
@@ -122,9 +130,9 @@ exports[`db2 export table command should display the help 1`] = `
   \\"success\\": true,
   \\"exitCode\\": 0,
   \\"message\\": \\"The help was constructed for command: table.\\",
-  \\"stdout\\": \\"\\\\n COMMAND NAME\\\\n ------------\\\\n\\\\n   table\\\\n\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Export a Db2 table to the stdout or a file.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 export table <table> [options]\\\\n\\\\n POSITIONAL ARGUMENTS\\\\n --------------------\\\\n\\\\n   table\\\\t\\\\t (string)\\\\n\\\\n      The name of the table to export\\\\n\\\\n OPTIONS\\\\n -------\\\\n\\\\n   --outfile  | -o (string)\\\\n\\\\n      The path to the output file\\\\n\\\\n   --separator  | --sep (string)\\\\n\\\\n      Specify whether to add a separator between statements when exporting a table\\\\n\\\\n DB2 CONNECTION OPTIONS\\\\n ----------------------\\\\n\\\\n   --host  | -H (string)\\\\n\\\\n      The Db2 server host name\\\\n\\\\n   --port  | -P (number)\\\\n\\\\n      The Db2 server port number\\\\n\\\\n   --user  | -u (string)\\\\n\\\\n      The Db2 user ID (may be the same as the TSO login)\\\\n\\\\n   --password  | --pass | --pw (string)\\\\n\\\\n      The Db2 password (may be the same as the TSO password)\\\\n\\\\n   --database  | --db (string)\\\\n\\\\n      The name of the database\\\\n\\\\n   --sslFile  | --ssl (string)\\\\n\\\\n      Path to an SSL Certificate file\\\\n\\\\n PROFILE OPTIONS\\\\n ---------------\\\\n\\\\n   --db2-profile  | --db2-p (string)\\\\n\\\\n      The name of a (db2) profile to load for this command execution.\\\\n\\\\n   --base-profile  | --base-p (string)\\\\n\\\\n      The name of a (base) profile to load for this command execution.\\\\n\\\\n BASE CONNECTION OPTIONS\\\\n -----------------------\\\\n\\\\n   --reject-unauthorized  | --ru (boolean)\\\\n\\\\n      Reject self-signed certificates.\\\\n\\\\n      Default value: true\\\\n\\\\n   --token-type  | --tt (string)\\\\n\\\\n      The type of token to get and use for the API. Omit this option to use the\\\\n      default token type, which is provided by 'zowe auth login'.\\\\n\\\\n   --token-value  | --tv (string)\\\\n\\\\n      The value of the token to pass to the API.\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples  (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web  | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n EXAMPLES\\\\n --------\\\\n\\\\n   - Export employees data from the table SAMPLE.EMP and save it\\\\n   to the file 'employees.sql':\\\\n\\\\n      $ zowe db2 export table SAMPLE.EMP --outfile employees.sql\\\\n\\\\n\\",
+  \\"stdout\\": \\"\\\\n COMMAND NAME\\\\n ------------\\\\n\\\\n   table\\\\n\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Export a Db2 table to the stdout or a file.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 export table <table> [options]\\\\n\\\\n POSITIONAL ARGUMENTS\\\\n --------------------\\\\n\\\\n   table\\\\t\\\\t (string)\\\\n\\\\n      The name of the table to export\\\\n\\\\n OPTIONS\\\\n -------\\\\n\\\\n   --outfile | -o (string)\\\\n\\\\n      The path to the output file\\\\n\\\\n   --separator | --sep (string)\\\\n\\\\n      Specify whether to add a separator between statements when exporting a table\\\\n\\\\n DB2 CONNECTION OPTIONS\\\\n ----------------------\\\\n\\\\n   --host | -H (string)\\\\n\\\\n      The Db2 server host name\\\\n\\\\n   --port | -P (number)\\\\n\\\\n      The Db2 server port number\\\\n\\\\n   --user | -u (string)\\\\n\\\\n      The Db2 user ID (may be the same as the TSO login)\\\\n\\\\n   --password | --pass | --pw (string)\\\\n\\\\n      The Db2 password (may be the same as the TSO password)\\\\n\\\\n   --database | --db (string)\\\\n\\\\n      The name of the database\\\\n\\\\n   --sslFile | --ssl (string)\\\\n\\\\n      Path to an SSL Certificate file\\\\n\\\\n PROFILE OPTIONS\\\\n ---------------\\\\n\\\\n   --db2-profile | --db2-p (string)\\\\n\\\\n      The name of a (db2) profile to load for this command execution.\\\\n\\\\n   --base-profile | --base-p (string)\\\\n\\\\n      The name of a (base) profile to load for this command execution.\\\\n\\\\n BASE CONNECTION OPTIONS\\\\n -----------------------\\\\n\\\\n   --reject-unauthorized | --ru (boolean)\\\\n\\\\n      Reject self-signed certificates.\\\\n\\\\n      Default value: true\\\\n\\\\n   --token-type | --tt (string)\\\\n\\\\n      The type of token to get and use for the API. Omit this option to use the\\\\n      default token type, which is provided by 'zowe auth login'.\\\\n\\\\n   --token-value | --tv (string)\\\\n\\\\n      The value of the token to pass to the API.\\\\n\\\\n   --cert-file (local file path)\\\\n\\\\n      The file path to a certificate file to use for authentication\\\\n\\\\n   --cert-key-file (local file path)\\\\n\\\\n      The file path to a certificate key file to use for authentication\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n EXAMPLES\\\\n --------\\\\n\\\\n   - Export employees data from the table SAMPLE.EMP and save it\\\\n   to the file 'employees.sql':\\\\n\\\\n      $ zowe db2 export table SAMPLE.EMP --outfile employees.sql\\\\n\\\\n\\",
   \\"stderr\\": \\"\\",
-  \\"data\\": \\"\\\\n COMMAND NAME\\\\n ------------\\\\n\\\\n   table\\\\n\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Export a Db2 table to the stdout or a file.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 export table <table> [options]\\\\n\\\\n POSITIONAL ARGUMENTS\\\\n --------------------\\\\n\\\\n   table\\\\t\\\\t (string)\\\\n\\\\n      The name of the table to export\\\\n\\\\n OPTIONS\\\\n -------\\\\n\\\\n   --outfile  | -o (string)\\\\n\\\\n      The path to the output file\\\\n\\\\n   --separator  | --sep (string)\\\\n\\\\n      Specify whether to add a separator between statements when exporting a table\\\\n\\\\n DB2 CONNECTION OPTIONS\\\\n ----------------------\\\\n\\\\n   --host  | -H (string)\\\\n\\\\n      The Db2 server host name\\\\n\\\\n   --port  | -P (number)\\\\n\\\\n      The Db2 server port number\\\\n\\\\n   --user  | -u (string)\\\\n\\\\n      The Db2 user ID (may be the same as the TSO login)\\\\n\\\\n   --password  | --pass | --pw (string)\\\\n\\\\n      The Db2 password (may be the same as the TSO password)\\\\n\\\\n   --database  | --db (string)\\\\n\\\\n      The name of the database\\\\n\\\\n   --sslFile  | --ssl (string)\\\\n\\\\n      Path to an SSL Certificate file\\\\n\\\\n PROFILE OPTIONS\\\\n ---------------\\\\n\\\\n   --db2-profile  | --db2-p (string)\\\\n\\\\n      The name of a (db2) profile to load for this command execution.\\\\n\\\\n   --base-profile  | --base-p (string)\\\\n\\\\n      The name of a (base) profile to load for this command execution.\\\\n\\\\n BASE CONNECTION OPTIONS\\\\n -----------------------\\\\n\\\\n   --reject-unauthorized  | --ru (boolean)\\\\n\\\\n      Reject self-signed certificates.\\\\n\\\\n      Default value: true\\\\n\\\\n   --token-type  | --tt (string)\\\\n\\\\n      The type of token to get and use for the API. Omit this option to use the\\\\n      default token type, which is provided by 'zowe auth login'.\\\\n\\\\n   --token-value  | --tv (string)\\\\n\\\\n      The value of the token to pass to the API.\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples  (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web  | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n EXAMPLES\\\\n --------\\\\n\\\\n   - Export employees data from the table SAMPLE.EMP and save it\\\\n   to the file 'employees.sql':\\\\n\\\\n      $ zowe db2 export table SAMPLE.EMP --outfile employees.sql\\\\n\\\\n\\"
+  \\"data\\": \\"\\\\n COMMAND NAME\\\\n ------------\\\\n\\\\n   table\\\\n\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Export a Db2 table to the stdout or a file.\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 export table <table> [options]\\\\n\\\\n POSITIONAL ARGUMENTS\\\\n --------------------\\\\n\\\\n   table\\\\t\\\\t (string)\\\\n\\\\n      The name of the table to export\\\\n\\\\n OPTIONS\\\\n -------\\\\n\\\\n   --outfile | -o (string)\\\\n\\\\n      The path to the output file\\\\n\\\\n   --separator | --sep (string)\\\\n\\\\n      Specify whether to add a separator between statements when exporting a table\\\\n\\\\n DB2 CONNECTION OPTIONS\\\\n ----------------------\\\\n\\\\n   --host | -H (string)\\\\n\\\\n      The Db2 server host name\\\\n\\\\n   --port | -P (number)\\\\n\\\\n      The Db2 server port number\\\\n\\\\n   --user | -u (string)\\\\n\\\\n      The Db2 user ID (may be the same as the TSO login)\\\\n\\\\n   --password | --pass | --pw (string)\\\\n\\\\n      The Db2 password (may be the same as the TSO password)\\\\n\\\\n   --database | --db (string)\\\\n\\\\n      The name of the database\\\\n\\\\n   --sslFile | --ssl (string)\\\\n\\\\n      Path to an SSL Certificate file\\\\n\\\\n PROFILE OPTIONS\\\\n ---------------\\\\n\\\\n   --db2-profile | --db2-p (string)\\\\n\\\\n      The name of a (db2) profile to load for this command execution.\\\\n\\\\n   --base-profile | --base-p (string)\\\\n\\\\n      The name of a (base) profile to load for this command execution.\\\\n\\\\n BASE CONNECTION OPTIONS\\\\n -----------------------\\\\n\\\\n   --reject-unauthorized | --ru (boolean)\\\\n\\\\n      Reject self-signed certificates.\\\\n\\\\n      Default value: true\\\\n\\\\n   --token-type | --tt (string)\\\\n\\\\n      The type of token to get and use for the API. Omit this option to use the\\\\n      default token type, which is provided by 'zowe auth login'.\\\\n\\\\n   --token-value | --tv (string)\\\\n\\\\n      The value of the token to pass to the API.\\\\n\\\\n   --cert-file (local file path)\\\\n\\\\n      The file path to a certificate file to use for authentication\\\\n\\\\n   --cert-key-file (local file path)\\\\n\\\\n      The file path to a certificate key file to use for authentication\\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n EXAMPLES\\\\n --------\\\\n\\\\n   - Export employees data from the table SAMPLE.EMP and save it\\\\n   to the file 'employees.sql':\\\\n\\\\n      $ zowe db2 export table SAMPLE.EMP --outfile employees.sql\\\\n\\\\n\\"
 }"
 `;
 
@@ -149,7 +157,7 @@ exports[`db2 export table command should fail with invalid option 1`] = `
 "Command Error:
 Unknown argument: format
 Command failed due to improper syntax
-Command entered: \\"zowe db2 export table SYSIBM.SYSDUMMY1 --format json\\"
+Command entered: \\"db2 export table SYSIBM.SYSDUMMY1 --format json\\"
 Available commands are \\"table\\".
 Use \\"zowe db2 export --help\\" to view groups, commands, and options.
 Error Details:

--- a/__tests__/__system__/cli/root/__snapshots__/cli.db2.system.test.ts.snap
+++ b/__tests__/__system__/cli/root/__snapshots__/cli.db2.system.test.ts.snap
@@ -24,19 +24,19 @@ exports[`db2 command should display the help 1`] = `
  GLOBAL OPTIONS
  --------------
 
-   --response-format-json  | --rfj (boolean)
+   --response-format-json | --rfj (boolean)
 
       Produce JSON formatted data from a command
 
-   --help  | -h (boolean)
+   --help | -h (boolean)
 
       Display help text
 
-   --help-examples  (boolean)
+   --help-examples (boolean)
 
       Display examples for all the commands in a group
 
-   --help-web  | --hw (boolean)
+   --help-web | --hw (boolean)
 
       Display HTML help in browser
 
@@ -44,9 +44,9 @@ exports[`db2 command should display the help 1`] = `
   \\"success\\": true,
   \\"exitCode\\": 0,
   \\"message\\": \\"The help was constructed for command: db2.\\",
-  \\"stdout\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Interact with IBM Db2 for z/OS\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 <group>\\\\n\\\\n   Where <group> is one of the following:\\\\n\\\\n GROUPS\\\\n ------\\\\n\\\\n   call    Call a stored procedure\\\\n   execute Execute a SQL query    \\\\n   export  Export a table         \\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples  (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web  | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n\\",
+  \\"stdout\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Interact with IBM Db2 for z/OS\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 <group>\\\\n\\\\n   Where <group> is one of the following:\\\\n\\\\n GROUPS\\\\n ------\\\\n\\\\n   call    Call a stored procedure\\\\n   execute Execute a SQL query    \\\\n   export  Export a table         \\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n\\",
   \\"stderr\\": \\"\\",
-  \\"data\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Interact with IBM Db2 for z/OS\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 <group>\\\\n\\\\n   Where <group> is one of the following:\\\\n\\\\n GROUPS\\\\n ------\\\\n\\\\n   call    Call a stored procedure\\\\n   execute Execute a SQL query    \\\\n   export  Export a table         \\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json  | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help  | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples  (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web  | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n\\"
+  \\"data\\": \\"\\\\n DESCRIPTION\\\\n -----------\\\\n\\\\n   Interact with IBM Db2 for z/OS\\\\n\\\\n USAGE\\\\n -----\\\\n\\\\n   zowe db2 <group>\\\\n\\\\n   Where <group> is one of the following:\\\\n\\\\n GROUPS\\\\n ------\\\\n\\\\n   call    Call a stored procedure\\\\n   execute Execute a SQL query    \\\\n   export  Export a table         \\\\n\\\\n GLOBAL OPTIONS\\\\n --------------\\\\n\\\\n   --response-format-json | --rfj (boolean)\\\\n\\\\n      Produce JSON formatted data from a command\\\\n\\\\n   --help | -h (boolean)\\\\n\\\\n      Display help text\\\\n\\\\n   --help-examples (boolean)\\\\n\\\\n      Display examples for all the commands in a group\\\\n\\\\n   --help-web | --hw (boolean)\\\\n\\\\n      Display HTML help in browser\\\\n\\\\n\\"
 }"
 `;
 
@@ -54,7 +54,9 @@ exports[`db2 command should fail with invalid option 1`] = `
 "Command Error:
 Unknown arguments: command, D
 Command failed due to improper syntax
-Command entered: \\"zowe db2 --command -D DDF\\"
+Did you mean: db2 call sp?
+
+Command entered: \\"db2 --command -D DDF\\"
 Use \\"zowe db2 --help\\" to view groups, commands, and options.
 Error Details:
 Unknown arguments: command, D
@@ -67,7 +69,9 @@ exports[`db2 command should fail with invalid parameter 1`] = `
 "Command Error:
 Unknown arguments: drop, DEMOUSER.DEMOTABLE
 Command failed due to improper syntax
-Command entered: \\"zowe db2 drop DEMOUSER.DEMOTABLE\\"
+Did you mean: db2 call proc?
+
+Command entered: \\"db2 drop DEMOUSER.DEMOTABLE\\"
 Use \\"zowe db2 --help\\" to view groups, commands, and options.
 Error Details:
 Unknown arguments: drop, DEMOUSER.DEMOTABLE

--- a/__tests__/api/__snapshots__/SessionValidator.test.ts.snap
+++ b/__tests__/api/__snapshots__/SessionValidator.test.ts.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SessionValidator validate should fail validating a DB2 session object with empty 'database' field 1`] = `"Error: Expect Error: Required parameter '[object Object]No DB2 database name was supplied.' must not be blank"`;
+exports[`SessionValidator validate should fail validating a DB2 session object with empty 'database' field 1`] = `"Error: Expect Error: Required parameter 'database' must not be blank"`;
 
-exports[`SessionValidator validate should fail validating a DB2 session object with empty 'hostname' field 1`] = `"Error: Expect Error: Required object must be defined"`;
+exports[`SessionValidator validate should fail validating a DB2 session object with empty 'hostname' field 1`] = `"Error: Expect Error: Imperative API Error - No DB2 server hostname was supplied."`;
 
-exports[`SessionValidator validate should fail validating a DB2 session object with empty 'password' field 1`] = `"Error: Expect Error: Required object must be defined"`;
+exports[`SessionValidator validate should fail validating a DB2 session object with empty 'password' field 1`] = `"Error: Expect Error: Imperative API Error - No DB2 user password was supplied."`;
 
-exports[`SessionValidator validate should fail validating a DB2 session object with empty 'port' field 1`] = `"Error: Expect Error: [object Object]No DB2 server port number was supplied."`;
+exports[`SessionValidator validate should fail validating a DB2 session object with empty 'port' field 1`] = `"Error: Expect Error: Imperative API Error - No DB2 server port number was supplied."`;
 
-exports[`SessionValidator validate should fail validating a DB2 session object with empty 'username' field 1`] = `"Error: Expect Error: Required object must be defined"`;
+exports[`SessionValidator validate should fail validating a DB2 session object with empty 'username' field 1`] = `"Error: Expect Error: Imperative API Error - No DB2 User ID was supplied."`;
 
-exports[`SessionValidator validate should fail validating a null DB2 session object 1`] = `"Error: Expect Error: [object Object]No DB2 parameters were supplied."`;
+exports[`SessionValidator validate should fail validating a null DB2 session object 1`] = `"Error: Expect Error: Imperative API Error - No DB2 parameters were supplied."`;
 
-exports[`SessionValidator validate should fail validating an empty DB2 session object 1`] = `"Error: Expect Error: Required object must be defined"`;
+exports[`SessionValidator validate should fail validating an empty DB2 session object 1`] = `"Error: Expect Error: Imperative API Error - No DB2 server hostname was supplied."`;

--- a/src/api/SessionValidator.ts
+++ b/src/api/SessionValidator.ts
@@ -28,10 +28,10 @@ export class SessionValidator {
      */
     public static validate(params: IDB2Session) {
         ImperativeExpect.toNotBeNullOrUndefined(params, noDB2Input.message);
-        ImperativeExpect.toBeDefinedAndNonBlank(params.hostname, noHostName.message);
+        ImperativeExpect.toBeDefinedAndNonBlank(params.hostname, "hostname", noHostName.message);
         ImperativeExpect.toNotBeNullOrUndefined(params.port, noPortNumber.message);
-        ImperativeExpect.toBeDefinedAndNonBlank(params.user, noUserName.message);
-        ImperativeExpect.toBeDefinedAndNonBlank(params.password, noPassword.message);
-        ImperativeExpect.toBeDefinedAndNonBlank(params.database, noDatabaseName.message);
+        ImperativeExpect.toBeDefinedAndNonBlank(params.user, "user", noUserName.message);
+        ImperativeExpect.toBeDefinedAndNonBlank(params.password, "password", noPassword.message);
+        ImperativeExpect.toBeDefinedAndNonBlank(params.database, "database", noDatabaseName.message);
     }
 }

--- a/src/api/doc/Messages.ts
+++ b/src/api/doc/Messages.ts
@@ -12,29 +12,29 @@
 import { IMessageDefinition, apiErrorHeader } from "@zowe/imperative";
 
 export const noDB2Input: IMessageDefinition = {
-    message: apiErrorHeader + "No DB2 parameters were supplied.",
+    message: apiErrorHeader.message + " - No DB2 parameters were supplied.",
 };
 
 export const noHostName: IMessageDefinition = {
-    message: apiErrorHeader + "No DB2 server hostname was supplied.",
+    message: apiErrorHeader.message + " - No DB2 server hostname was supplied.",
 };
 
 export const noPortNumber: IMessageDefinition = {
-    message: apiErrorHeader + "No DB2 server port number was supplied.",
+    message: apiErrorHeader.message + " - No DB2 server port number was supplied.",
 };
 
 export const noUserName: IMessageDefinition = {
-    message: apiErrorHeader + "No DB2 User ID was supplied.",
+    message: apiErrorHeader.message + " - No DB2 User ID was supplied.",
 };
 
 export const noPassword: IMessageDefinition = {
-    message: apiErrorHeader + "No DB2 user password was supplied.",
+    message: apiErrorHeader.message + " - No DB2 user password was supplied.",
 };
 
 export const noDatabaseName: IMessageDefinition = {
-    message: apiErrorHeader + "No DB2 database name was supplied.",
+    message: apiErrorHeader.message + " - No DB2 database name was supplied.",
 };
 
 export const noTableName: IMessageDefinition = {
-    message: apiErrorHeader + "No DB2 table name was supplied.",
+    message: apiErrorHeader.message + " - No DB2 table name was supplied.",
 };

--- a/src/cli/DB2BaseHandler.ts
+++ b/src/cli/DB2BaseHandler.ts
@@ -32,7 +32,7 @@ export abstract class DB2BaseHandler implements ICommandHandler {
      */
     public async process(commandParameters: IHandlerParameters) {
         this.mHandlerParams = commandParameters;
-        const session = await DB2Session.createSessCfgFromArgs(commandParameters.arguments);
+        const session = await DB2Session.createSessCfgFromArgs(commandParameters.arguments, true, commandParameters);
         await this.processWithDB2Session(commandParameters, session);
     }
 

--- a/src/cli/DB2Session.ts
+++ b/src/cli/DB2Session.ts
@@ -10,7 +10,7 @@
 */
 
 
-import { ConnectionPropsForSessCfg, ICommandArguments, ICommandOptionDefinition, Logger, Session } from "@zowe/imperative";
+import { ConnectionPropsForSessCfg, ICommandArguments, ICommandOptionDefinition, IHandlerParameters, Logger, Session } from "@zowe/imperative";
 import { IDB2Session } from "../rest/session/doc/IDB2Session";
 
 /**
@@ -126,7 +126,7 @@ export class DB2Session {
      * @param {boolean} doPrompting - Whether to prompt for missing arguments (defaults to true)
      * @returns {Session} - A session for usage in the CMCI REST Client
      */
-    public static async createSessCfgFromArgs(args: ICommandArguments, doPrompting = true): Promise<Session> {
+    public static async createSessCfgFromArgs(args: ICommandArguments, doPrompting = true, handler?: IHandlerParameters): Promise<Session> {
         const sessCfg: IDB2Session = {
             hostname: args.host,
             port: args.port,
@@ -136,7 +136,7 @@ export class DB2Session {
             sslFile: args.sslFile,
         };
 
-        const sessCfgWithCreds = await ConnectionPropsForSessCfg.addPropsOrPrompt<IDB2Session>(sessCfg, args, {doPrompting});
+        const sessCfgWithCreds = await ConnectionPropsForSessCfg.addPropsOrPrompt<IDB2Session>(sessCfg, args, {doPrompting, parms: handler});
         return new Session(sessCfgWithCreds);
     }
 

--- a/src/cli/DB2Session.ts
+++ b/src/cli/DB2Session.ts
@@ -124,9 +124,10 @@ export class DB2Session {
      * @static
      * @param {IProfile} args - The arguments specified by the user
      * @param {boolean} doPrompting - Whether to prompt for missing arguments (defaults to true)
+     * @param {IHandlerParameters} handlerParams - The command parameters object for Daemon mode prompting
      * @returns {Session} - A session for usage in the CMCI REST Client
      */
-    public static async createSessCfgFromArgs(args: ICommandArguments, doPrompting = true, handler?: IHandlerParameters): Promise<Session> {
+    public static async createSessCfgFromArgs(args: ICommandArguments, doPrompting = true, handlerParams?: IHandlerParameters): Promise<Session> {
         const sessCfg: IDB2Session = {
             hostname: args.host,
             port: args.port,
@@ -136,7 +137,7 @@ export class DB2Session {
             sslFile: args.sslFile,
         };
 
-        const sessCfgWithCreds = await ConnectionPropsForSessCfg.addPropsOrPrompt<IDB2Session>(sessCfg, args, {doPrompting, parms: handler});
+        const sessCfgWithCreds = await ConnectionPropsForSessCfg.addPropsOrPrompt<IDB2Session>(sessCfg, args, {doPrompting, parms: handlerParams});
         return new Session(sessCfgWithCreds);
     }
 


### PR DESCRIPTION
Adds required parameters to fix daemon mode prompting in next.
Fixes error messages returned when user, password, port, host, or database are omitted from the session object.
Updates snapshots.

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>