### PR TITLE
Update ibmdb v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® Db2® Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Update ibm_db to allow the plugin to install on M1 Macs.
+
 ## `4.1.5`
 
 - BugFix: Updated follow-redirects and minimist dependencies to resolve potential vulnerabilities.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6494,9 +6494,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "funding": [
         {
           "type": "individual",
@@ -11331,9 +11331,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minipass": {
       "version": "3.1.6",
@@ -20588,9 +20588,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -24236,9 +24236,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minipass": {
       "version": "3.1.6",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
       "version": "4.1.4",
       "license": "EPL-2.0",
       "dependencies": {
-        "ibm_db": "2.7.4"
+        "ibm_db": "2.8.1"
       },
       "devDependencies": {
         "@types/fs-extra": "^5.0.5",
@@ -40,7 +40,7 @@
         "uuid": "^3.2.1"
       },
       "peerDependencies": {
-        "@zowe/cli": "^6.37.6",
+        "@zowe/cli": "^6.0.0",
         "@zowe/imperative": "^4.0.0"
       }
     },
@@ -7060,19 +7060,21 @@
       }
     },
     "node_modules/ibm_db": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ibm_db/-/ibm_db-2.7.4.tgz",
-      "integrity": "sha512-jsymE7j9EVw3ixqDFqWWv0lp7/GWp6dmW+D/93gJEQ+MKbyQWMKBzhda2pkHWRZPgq3xVPGdHGEJf6+KDNXQZw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/ibm_db/-/ibm_db-2.8.1.tgz",
+      "integrity": "sha512-w4q5UN5FNRf4PW2yDG3uQVnA81vy2GS4vkGwigKgBuUMRa+pNgbAtTkhv3w/9Vz12X6YiYK9hFcwlVomKdj0qw==",
       "hasInstallScript": true,
       "dependencies": {
         "axios": "^0.21.1",
+        "big-integer": "^1.6.51",
         "bindings": "^1.5.0",
         "fs-extra": "^8.1.0",
         "fstream": "^1.0.12",
-        "nan": "^2.14.0",
+        "lodash": "^4.17.21",
+        "nan": "^2.15.0",
         "q": "^1.5.1",
         "targz": "^1.0.1",
-        "unzipper": "^0.10.5"
+        "unzipper": "^0.10.11"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -21002,18 +21004,20 @@
       }
     },
     "ibm_db": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ibm_db/-/ibm_db-2.7.4.tgz",
-      "integrity": "sha512-jsymE7j9EVw3ixqDFqWWv0lp7/GWp6dmW+D/93gJEQ+MKbyQWMKBzhda2pkHWRZPgq3xVPGdHGEJf6+KDNXQZw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/ibm_db/-/ibm_db-2.8.1.tgz",
+      "integrity": "sha512-w4q5UN5FNRf4PW2yDG3uQVnA81vy2GS4vkGwigKgBuUMRa+pNgbAtTkhv3w/9Vz12X6YiYK9hFcwlVomKdj0qw==",
       "requires": {
         "axios": "^0.21.1",
+        "big-integer": "^1.6.51",
         "bindings": "^1.5.0",
         "fs-extra": "^8.1.0",
         "fstream": "^1.0.12",
-        "nan": "^2.14.0",
+        "lodash": "^4.17.21",
+        "nan": "^2.15.0",
         "q": "^1.5.1",
         "targz": "^1.0.1",
-        "unzipper": "^0.10.5"
+        "unzipper": "^0.10.11"
       },
       "dependencies": {
         "fs-extra": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20,7 +20,7 @@
         "@types/yargs": "^8.0.2",
         "@typescript-eslint/eslint-plugin": "^4.29.0",
         "@typescript-eslint/parser": "^4.29.0",
-        "@zowe/imperative": "4.18.1",
+        "@zowe/imperative": "4.18.2",
         "env-cmd": "^8.0.2",
         "eslint": "^7.32.0",
         "eslint-plugin-jest": "^24.4.0",
@@ -3239,25 +3239,25 @@
       }
     },
     "node_modules/@zowe/cli": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/cli/-/@zowe/cli-6.37.6.tgz",
-      "integrity": "sha1-CRhsvspUmvU4rFkpxOMFrn648OA=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/cli/-/@zowe/cli-6.39.1.tgz",
+      "integrity": "sha512-mgLISPdbdDTDETkyfZy4bNfM4cwXCk4aY0VSIm/am5yJ4KqEwVxdpfA+r9o2qHnn+/WYkvV4pUeUF86x/qTJaQ==",
       "hasInstallScript": true,
       "license": "EPL-2.0",
       "peer": true,
       "dependencies": {
-        "@zowe/core-for-zowe-sdk": "6.37.6",
-        "@zowe/imperative": "4.17.6",
+        "@zowe/core-for-zowe-sdk": "6.39.1",
+        "@zowe/imperative": "4.18.2",
         "@zowe/perf-timing": "1.0.7",
-        "@zowe/provisioning-for-zowe-sdk": "6.37.6",
-        "@zowe/zos-console-for-zowe-sdk": "6.37.6",
-        "@zowe/zos-files-for-zowe-sdk": "6.37.6",
-        "@zowe/zos-jobs-for-zowe-sdk": "6.37.6",
-        "@zowe/zos-logs-for-zowe-sdk": "6.37.6",
-        "@zowe/zos-tso-for-zowe-sdk": "6.37.6",
-        "@zowe/zos-uss-for-zowe-sdk": "6.37.6",
-        "@zowe/zos-workflows-for-zowe-sdk": "6.37.6",
-        "@zowe/zosmf-for-zowe-sdk": "6.37.6",
+        "@zowe/provisioning-for-zowe-sdk": "6.39.1",
+        "@zowe/zos-console-for-zowe-sdk": "6.39.1",
+        "@zowe/zos-files-for-zowe-sdk": "6.39.1",
+        "@zowe/zos-jobs-for-zowe-sdk": "6.39.1",
+        "@zowe/zos-logs-for-zowe-sdk": "6.39.1",
+        "@zowe/zos-tso-for-zowe-sdk": "6.39.1",
+        "@zowe/zos-uss-for-zowe-sdk": "6.39.1",
+        "@zowe/zos-workflows-for-zowe-sdk": "6.39.1",
+        "@zowe/zosmf-for-zowe-sdk": "6.39.1",
         "get-stdin": "7.0.0",
         "minimatch": "3.0.4"
       },
@@ -3269,97 +3269,10 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@zowe/cli/node_modules/@types/yargs": {
-      "version": "13.0.4",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.4.tgz",
-      "integrity": "sha512-Ke1WmBbIkVM8bpvsNEcGgQM70XcEh/nbpxQhW7FhrsbCsXSY9BmLB1+LHtD7r9zrsOcFlLiF+a/UeJsdfw3C5A==",
-      "peer": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@zowe/cli/node_modules/@zowe/imperative": {
-      "version": "4.17.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.17.6.tgz",
-      "integrity": "sha1-dqFi+GrBFC8DTu89620ecMQ2FU8=",
-      "license": "EPL-2.0",
-      "peer": true,
-      "dependencies": {
-        "@types/lodash-deep": "2.0.0",
-        "@types/yargs": "13.0.4",
-        "@zowe/perf-timing": "1.0.7",
-        "chalk": "2.4.2",
-        "cli-table3": "0.6.1",
-        "dataobject-parser": "1.2.1",
-        "deepmerge": "3.0.0",
-        "fastest-levenshtein": "1.0.12",
-        "find-up": "4.1.0",
-        "fs-extra": "8.1.0",
-        "glob": "7.1.6",
-        "js-yaml": "3.14.1",
-        "jsonfile": "4.0.0",
-        "jsonschema": "1.1.1",
-        "lodash-deep": "2.0.0",
-        "log4js": "6.4.0",
-        "markdown-it": "12.3.2",
-        "moment": "2.20.1",
-        "mustache": "2.3.0",
-        "npm-package-arg": "8.1.1",
-        "opener": "1.5.2",
-        "pacote": "11.1.4",
-        "prettyjson": "1.2.2",
-        "progress": "2.0.3",
-        "readline-sync": "1.4.10",
-        "rimraf": "2.6.3",
-        "semver": "5.7.0",
-        "stack-trace": "0.0.10",
-        "wrap-ansi": "7.0.0",
-        "yamljs": "0.3.0",
-        "yargs": "15.3.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@zowe/cli/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@zowe/cli/node_modules/rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/@zowe/cli/node_modules/semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/@zowe/core-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/core-for-zowe-sdk/-/@zowe/core-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-EXnT+aYIs8Y2RBt8GCAmq4pRmoM=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/core-for-zowe-sdk/-/@zowe/core-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-ilLJRTWcaOzcHfRMSWhgL79/jap1JsyPa04wYRaxY+AQgKy5GFqAMCDJTKyReOcwIKoMlwInXYtU7AHeXFEYYQ==",
       "license": "EPL-2.0",
       "peer": true,
       "dependencies": {
@@ -3370,9 +3283,9 @@
       }
     },
     "node_modules/@zowe/imperative": {
-      "version": "4.18.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.18.1.tgz",
-      "integrity": "sha512-Ohs8pmGEl8YEhs4BJ/yq0Q4XzM8H6FrlORqfULSbwx8m0DKN6ZCQHVEPQLky1V6xbnx70IQC5NDHPPf0w5tncA==",
+      "version": "4.18.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.18.2.tgz",
+      "integrity": "sha512-OSpzclobIxXwlZmkHtY1mfGnvJkHwDpTJ5HQ3zxR0IAmbnFDUVmoX2tYnHJIVAx2v4TLCTLvEjHs8rXzoMhsyQ==",
       "license": "EPL-2.0",
       "dependencies": {
         "@types/lodash-deep": "2.0.0",
@@ -3392,7 +3305,7 @@
         "lodash-deep": "2.0.0",
         "log4js": "6.4.0",
         "markdown-it": "12.3.2",
-        "moment": "2.20.1",
+        "moment": "2.29.2",
         "mustache": "2.3.0",
         "npm-package-arg": "8.1.1",
         "opener": "1.5.2",
@@ -3478,9 +3391,9 @@
       }
     },
     "node_modules/@zowe/provisioning-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/provisioning-for-zowe-sdk/-/@zowe/provisioning-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-keWneLKz1zghtmswfnHI0fVDpTA=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/provisioning-for-zowe-sdk/-/@zowe/provisioning-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-atqjlHnW0XXn0oCEjs9EBlJIcqBAXOaX/9/UKfOoZ1rd01Qln1TEd+ylHabN+jprMdCs6nFLVB7CvhSTJUZIdA==",
       "license": "EPL-2.0",
       "peer": true,
       "dependencies": {
@@ -3492,9 +3405,9 @@
       }
     },
     "node_modules/@zowe/zos-console-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-console-for-zowe-sdk/-/@zowe/zos-console-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-x/FMlMtlGII+wjglPqI3Ejvc2uw=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-console-for-zowe-sdk/-/@zowe/zos-console-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-44yidbiKj4bRERIwvrG+KT60Nl7HTFAdi7uPVjCPbPsYtBLj3MPJqWSU9AxzyfHtHXN6oKrwYPfxJt/dst7Iqg==",
       "license": "EPL-2.0",
       "peer": true,
       "peerDependencies": {
@@ -3503,9 +3416,9 @@
       }
     },
     "node_modules/@zowe/zos-files-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-files-for-zowe-sdk/-/@zowe/zos-files-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-zKZMXYdfpUqb1uaRuxUarEUxrU8=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-files-for-zowe-sdk/-/@zowe/zos-files-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-cPhgSGnQF+xG0EFjvWc+qVghc29c8PIuO8zxNSKNwbo2VaX3aQ0nXLaNMqkyFlrnGJhjFudouEYWtuKf9QeOkw==",
       "license": "EPL-2.0",
       "peer": true,
       "dependencies": {
@@ -3517,13 +3430,13 @@
       }
     },
     "node_modules/@zowe/zos-jobs-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-jobs-for-zowe-sdk/-/@zowe/zos-jobs-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-phy9uHzGaP9sEoHldnz4Wj6rLA8=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-jobs-for-zowe-sdk/-/@zowe/zos-jobs-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-5dx0cxV4aglI2R+nB4156TThsu7y2M2lKl6S4sgDmsQoSMdHZWr8+apDVTOUQeGhQ0FcJp1bx5LMsZq4Is9Vpg==",
       "license": "EPL-2.0",
       "peer": true,
       "dependencies": {
-        "@zowe/zos-files-for-zowe-sdk": "6.37.6"
+        "@zowe/zos-files-for-zowe-sdk": "6.39.1"
       },
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": "^6.24.1",
@@ -3531,9 +3444,9 @@
       }
     },
     "node_modules/@zowe/zos-logs-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-logs-for-zowe-sdk/-/@zowe/zos-logs-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-MubfWbmXV6bKu10SO6BRws4torE=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-logs-for-zowe-sdk/-/@zowe/zos-logs-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-v/r3KFlfhU1fDNpiqEQ/sWZqHys2f3seJgs2XfvheH0KVDh5463ephcV1dmLEKWMEtEmo0APO+Nq+o/z/X2IWg==",
       "license": "EPL-2.0",
       "peer": true,
       "peerDependencies": {
@@ -3542,13 +3455,13 @@
       }
     },
     "node_modules/@zowe/zos-tso-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-tso-for-zowe-sdk/-/@zowe/zos-tso-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-HAEPYSc9G5k1oBmCzeN0dDbI8ew=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-tso-for-zowe-sdk/-/@zowe/zos-tso-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-Dsy/UzLECB3kDlYilJTobgkLnFObES+Vl29Q37Q83mtOYMpRkQb+9wxIYuKs+UqJZDp+tMfzie79W5P28od1nQ==",
       "license": "EPL-2.0",
       "peer": true,
       "dependencies": {
-        "@zowe/zosmf-for-zowe-sdk": "6.37.6"
+        "@zowe/zosmf-for-zowe-sdk": "6.39.1"
       },
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": "^6.24.1",
@@ -3556,9 +3469,9 @@
       }
     },
     "node_modules/@zowe/zos-uss-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-uss-for-zowe-sdk/-/@zowe/zos-uss-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-Avs2oqCqnKkkiySPY4+BdL3B/0s=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-uss-for-zowe-sdk/-/@zowe/zos-uss-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-kf8SQXVWHeNh6pcnl2pEpaIWCAp6V+4wFSXcr7FhyJzxBmSJF7krDe7daK8k3QuemIh+KkrmMMX6VYFOHbJAPQ==",
       "license": "EPL-2.0",
       "peer": true,
       "dependencies": {
@@ -3569,13 +3482,13 @@
       }
     },
     "node_modules/@zowe/zos-workflows-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-workflows-for-zowe-sdk/-/@zowe/zos-workflows-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-8ZFNHO3V+HJ4n0t/1m9pykrzzxM=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-workflows-for-zowe-sdk/-/@zowe/zos-workflows-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-a87KvZPjUanfvK0RAvp/Y9/gqKN5JwCiJeRJla0eBuIZ80iOMvs1plNW8F3It6zQqasph0A0We8f5cc/cCMQ7Q==",
       "license": "EPL-2.0",
       "peer": true,
       "dependencies": {
-        "@zowe/zos-files-for-zowe-sdk": "6.37.6"
+        "@zowe/zos-files-for-zowe-sdk": "6.39.1"
       },
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": "^6.24.1",
@@ -3583,9 +3496,9 @@
       }
     },
     "node_modules/@zowe/zosmf-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zosmf-for-zowe-sdk/-/@zowe/zosmf-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-COdhSRoQIj95c6FUf4rs6C2aCBE=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zosmf-for-zowe-sdk/-/@zowe/zosmf-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-fpqN9LbP3Q8d2WzidMYSXpUHv9v8WkF41Gx4WHc4Dxfm3QjMvIYHcG0N+rFgtyb83Q6Y2xA9dUkwxxQ1fLbB5w==",
       "license": "EPL-2.0",
       "peer": true,
       "peerDependencies": {
@@ -8754,9 +8667,9 @@
       }
     },
     "node_modules/jest-junit/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -10234,15 +10147,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jest-stare/node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/jest-stare/node_modules/mustache": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
@@ -11580,9 +11484,9 @@
       "dev": true
     },
     "node_modules/moment": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg==",
+      "version": "2.29.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
       "engines": {
         "node": "*"
       }
@@ -18186,116 +18090,40 @@
       }
     },
     "@zowe/cli": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/cli/-/@zowe/cli-6.37.6.tgz",
-      "integrity": "sha1-CRhsvspUmvU4rFkpxOMFrn648OA=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/cli/-/@zowe/cli-6.39.1.tgz",
+      "integrity": "sha512-mgLISPdbdDTDETkyfZy4bNfM4cwXCk4aY0VSIm/am5yJ4KqEwVxdpfA+r9o2qHnn+/WYkvV4pUeUF86x/qTJaQ==",
       "peer": true,
       "requires": {
-        "@zowe/core-for-zowe-sdk": "6.37.6",
-        "@zowe/imperative": "4.17.6",
+        "@zowe/core-for-zowe-sdk": "6.39.1",
+        "@zowe/imperative": "4.18.2",
         "@zowe/perf-timing": "1.0.7",
-        "@zowe/provisioning-for-zowe-sdk": "6.37.6",
-        "@zowe/zos-console-for-zowe-sdk": "6.37.6",
-        "@zowe/zos-files-for-zowe-sdk": "6.37.6",
-        "@zowe/zos-jobs-for-zowe-sdk": "6.37.6",
-        "@zowe/zos-logs-for-zowe-sdk": "6.37.6",
-        "@zowe/zos-tso-for-zowe-sdk": "6.37.6",
-        "@zowe/zos-uss-for-zowe-sdk": "6.37.6",
-        "@zowe/zos-workflows-for-zowe-sdk": "6.37.6",
-        "@zowe/zosmf-for-zowe-sdk": "6.37.6",
+        "@zowe/provisioning-for-zowe-sdk": "6.39.1",
+        "@zowe/zos-console-for-zowe-sdk": "6.39.1",
+        "@zowe/zos-files-for-zowe-sdk": "6.39.1",
+        "@zowe/zos-jobs-for-zowe-sdk": "6.39.1",
+        "@zowe/zos-logs-for-zowe-sdk": "6.39.1",
+        "@zowe/zos-tso-for-zowe-sdk": "6.39.1",
+        "@zowe/zos-uss-for-zowe-sdk": "6.39.1",
+        "@zowe/zos-workflows-for-zowe-sdk": "6.39.1",
+        "@zowe/zosmf-for-zowe-sdk": "6.39.1",
         "get-stdin": "7.0.0",
         "minimatch": "3.0.4"
-      },
-      "dependencies": {
-        "@types/yargs": {
-          "version": "13.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.4.tgz",
-          "integrity": "sha512-Ke1WmBbIkVM8bpvsNEcGgQM70XcEh/nbpxQhW7FhrsbCsXSY9BmLB1+LHtD7r9zrsOcFlLiF+a/UeJsdfw3C5A==",
-          "peer": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "@zowe/imperative": {
-          "version": "4.17.6",
-          "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.17.6.tgz",
-          "integrity": "sha1-dqFi+GrBFC8DTu89620ecMQ2FU8=",
-          "peer": true,
-          "requires": {
-            "@types/lodash-deep": "2.0.0",
-            "@types/yargs": "13.0.4",
-            "@zowe/perf-timing": "1.0.7",
-            "chalk": "2.4.2",
-            "cli-table3": "0.6.1",
-            "dataobject-parser": "1.2.1",
-            "deepmerge": "3.0.0",
-            "fastest-levenshtein": "1.0.12",
-            "find-up": "4.1.0",
-            "fs-extra": "8.1.0",
-            "glob": "7.1.6",
-            "js-yaml": "3.14.1",
-            "jsonfile": "4.0.0",
-            "jsonschema": "1.1.1",
-            "lodash-deep": "2.0.0",
-            "log4js": "6.4.0",
-            "markdown-it": "12.3.2",
-            "moment": "2.20.1",
-            "mustache": "2.3.0",
-            "npm-package-arg": "8.1.1",
-            "opener": "1.5.2",
-            "pacote": "11.1.4",
-            "prettyjson": "1.2.2",
-            "progress": "2.0.3",
-            "readline-sync": "1.4.10",
-            "rimraf": "2.6.3",
-            "semver": "5.7.0",
-            "stack-trace": "0.0.10",
-            "wrap-ansi": "7.0.0",
-            "yamljs": "0.3.0",
-            "yargs": "15.3.1"
-          }
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "peer": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-          "peer": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-          "peer": true
-        }
       }
     },
     "@zowe/core-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/core-for-zowe-sdk/-/@zowe/core-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-EXnT+aYIs8Y2RBt8GCAmq4pRmoM=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/core-for-zowe-sdk/-/@zowe/core-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-ilLJRTWcaOzcHfRMSWhgL79/jap1JsyPa04wYRaxY+AQgKy5GFqAMCDJTKyReOcwIKoMlwInXYtU7AHeXFEYYQ==",
       "peer": true,
       "requires": {
         "string-width": "4.2.3"
       }
     },
     "@zowe/imperative": {
-      "version": "4.18.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.18.1.tgz",
-      "integrity": "sha512-Ohs8pmGEl8YEhs4BJ/yq0Q4XzM8H6FrlORqfULSbwx8m0DKN6ZCQHVEPQLky1V6xbnx70IQC5NDHPPf0w5tncA==",
+      "version": "4.18.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-4.18.2.tgz",
+      "integrity": "sha512-OSpzclobIxXwlZmkHtY1mfGnvJkHwDpTJ5HQ3zxR0IAmbnFDUVmoX2tYnHJIVAx2v4TLCTLvEjHs8rXzoMhsyQ==",
       "requires": {
         "@types/lodash-deep": "2.0.0",
         "@types/yargs": "13.0.4",
@@ -18314,7 +18142,7 @@
         "lodash-deep": "2.0.0",
         "log4js": "6.4.0",
         "markdown-it": "12.3.2",
-        "moment": "2.20.1",
+        "moment": "2.29.2",
         "mustache": "2.3.0",
         "npm-package-arg": "8.1.1",
         "opener": "1.5.2",
@@ -18385,77 +18213,77 @@
       }
     },
     "@zowe/provisioning-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/provisioning-for-zowe-sdk/-/@zowe/provisioning-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-keWneLKz1zghtmswfnHI0fVDpTA=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/provisioning-for-zowe-sdk/-/@zowe/provisioning-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-atqjlHnW0XXn0oCEjs9EBlJIcqBAXOaX/9/UKfOoZ1rd01Qln1TEd+ylHabN+jprMdCs6nFLVB7CvhSTJUZIdA==",
       "peer": true,
       "requires": {
         "js-yaml": "3.14.1"
       }
     },
     "@zowe/zos-console-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-console-for-zowe-sdk/-/@zowe/zos-console-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-x/FMlMtlGII+wjglPqI3Ejvc2uw=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-console-for-zowe-sdk/-/@zowe/zos-console-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-44yidbiKj4bRERIwvrG+KT60Nl7HTFAdi7uPVjCPbPsYtBLj3MPJqWSU9AxzyfHtHXN6oKrwYPfxJt/dst7Iqg==",
       "peer": true,
       "requires": {}
     },
     "@zowe/zos-files-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-files-for-zowe-sdk/-/@zowe/zos-files-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-zKZMXYdfpUqb1uaRuxUarEUxrU8=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-files-for-zowe-sdk/-/@zowe/zos-files-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-cPhgSGnQF+xG0EFjvWc+qVghc29c8PIuO8zxNSKNwbo2VaX3aQ0nXLaNMqkyFlrnGJhjFudouEYWtuKf9QeOkw==",
       "peer": true,
       "requires": {
         "minimatch": "3.0.4"
       }
     },
     "@zowe/zos-jobs-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-jobs-for-zowe-sdk/-/@zowe/zos-jobs-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-phy9uHzGaP9sEoHldnz4Wj6rLA8=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-jobs-for-zowe-sdk/-/@zowe/zos-jobs-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-5dx0cxV4aglI2R+nB4156TThsu7y2M2lKl6S4sgDmsQoSMdHZWr8+apDVTOUQeGhQ0FcJp1bx5LMsZq4Is9Vpg==",
       "peer": true,
       "requires": {
-        "@zowe/zos-files-for-zowe-sdk": "6.37.6"
+        "@zowe/zos-files-for-zowe-sdk": "6.39.1"
       }
     },
     "@zowe/zos-logs-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-logs-for-zowe-sdk/-/@zowe/zos-logs-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-MubfWbmXV6bKu10SO6BRws4torE=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-logs-for-zowe-sdk/-/@zowe/zos-logs-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-v/r3KFlfhU1fDNpiqEQ/sWZqHys2f3seJgs2XfvheH0KVDh5463ephcV1dmLEKWMEtEmo0APO+Nq+o/z/X2IWg==",
       "peer": true,
       "requires": {}
     },
     "@zowe/zos-tso-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-tso-for-zowe-sdk/-/@zowe/zos-tso-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-HAEPYSc9G5k1oBmCzeN0dDbI8ew=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-tso-for-zowe-sdk/-/@zowe/zos-tso-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-Dsy/UzLECB3kDlYilJTobgkLnFObES+Vl29Q37Q83mtOYMpRkQb+9wxIYuKs+UqJZDp+tMfzie79W5P28od1nQ==",
       "peer": true,
       "requires": {
-        "@zowe/zosmf-for-zowe-sdk": "6.37.6"
+        "@zowe/zosmf-for-zowe-sdk": "6.39.1"
       }
     },
     "@zowe/zos-uss-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-uss-for-zowe-sdk/-/@zowe/zos-uss-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-Avs2oqCqnKkkiySPY4+BdL3B/0s=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-uss-for-zowe-sdk/-/@zowe/zos-uss-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-kf8SQXVWHeNh6pcnl2pEpaIWCAp6V+4wFSXcr7FhyJzxBmSJF7krDe7daK8k3QuemIh+KkrmMMX6VYFOHbJAPQ==",
       "peer": true,
       "requires": {
         "ssh2": "1.4.0"
       }
     },
     "@zowe/zos-workflows-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-workflows-for-zowe-sdk/-/@zowe/zos-workflows-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-8ZFNHO3V+HJ4n0t/1m9pykrzzxM=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-workflows-for-zowe-sdk/-/@zowe/zos-workflows-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-a87KvZPjUanfvK0RAvp/Y9/gqKN5JwCiJeRJla0eBuIZ80iOMvs1plNW8F3It6zQqasph0A0We8f5cc/cCMQ7Q==",
       "peer": true,
       "requires": {
-        "@zowe/zos-files-for-zowe-sdk": "6.37.6"
+        "@zowe/zos-files-for-zowe-sdk": "6.39.1"
       }
     },
     "@zowe/zosmf-for-zowe-sdk": {
-      "version": "6.37.6",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zosmf-for-zowe-sdk/-/@zowe/zosmf-for-zowe-sdk-6.37.6.tgz",
-      "integrity": "sha1-COdhSRoQIj95c6FUf4rs6C2aCBE=",
+      "version": "6.39.1",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zosmf-for-zowe-sdk/-/@zowe/zosmf-for-zowe-sdk-6.39.1.tgz",
+      "integrity": "sha512-fpqN9LbP3Q8d2WzidMYSXpUHv9v8WkF41Gx4WHc4Dxfm3QjMvIYHcG0N+rFgtyb83Q6Y2xA9dUkwxxQ1fLbB5w==",
       "peer": true,
       "requires": {}
     },
@@ -22387,9 +22215,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
           "dev": true
         },
         "strip-ansi": {
@@ -23493,12 +23321,6 @@
             "path-exists": "^3.0.0"
           }
         },
-        "moment": {
-          "version": "2.29.1",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-          "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-          "dev": true
-        },
         "mustache": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
@@ -24522,9 +24344,9 @@
       }
     },
     "moment": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+      "version": "2.29.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/yargs": "^8.0.2",
     "@typescript-eslint/eslint-plugin": "^4.29.0",
     "@typescript-eslint/parser": "^4.29.0",
-    "@zowe/imperative": "4.18.1",
+    "@zowe/imperative": "4.18.2",
     "env-cmd": "^8.0.2",
     "eslint": "^7.32.0",
     "eslint-plugin-jest": "^24.4.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "configurationModule": "lib/imperative.js"
   },
   "dependencies": {
-    "ibm_db": "2.7.4"
+    "ibm_db": "2.8.1"
   },
   "peerDependencies": {
     "@zowe/cli": "^6.0.0",


### PR DESCRIPTION
Update ibm_db dependency to better support M1 Mac - note that the binary DOES NOT WORK, only installs.