### PR TITLE
Update ibm_db to support Node.js 18

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js LTS
       uses: actions/setup-node@v2
       with:
         node-version: lts/*

--- a/.github/workflows/zowe-cli-plugin.yml
+++ b/.github/workflows/zowe-cli-plugin.yml
@@ -69,6 +69,6 @@ jobs:
 
     - name: Upload Results to Codecov
       if: ${{ always() && steps.build.outcome == 'success' }}
-      uses: codecov/codecov-action@v1.0.7
+      uses: codecov/codecov-action@v3
       with:
         env_vars: OS,NODE

--- a/.github/workflows/zowe-cli-plugin.yml
+++ b/.github/workflows/zowe-cli-plugin.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [windows-latest, ubuntu-latest, macos-latest]
 
     env:
@@ -31,13 +31,13 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Use NPM v8
-      id: npm8
-      run: npm install -g npm@^8
+    - name: Update NPM
+      if: ${{ matrix.node-version == '14.x' }}
+      run: npm install -g npm@7
 
     - name: Install Node Package Dependencies
       id: install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the IBM® Db2® Plug-in for Zowe CLI will be documented i
 
 ## Recent Changes
 
-- BugFix: Updated ibm_db dependency to support Node.js 18
+- BugFix: Updated ibm_db dependency to be compatible with Node.js 18
 
 ## `5.0.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® Db2® Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Updated ibm_db dependency to support Node.js 18
+
 ## `5.0.0`
 
 - Major: Updated for V2 compatibility. See the prerelease items below for more details.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
       "version": "5.0.0",
       "license": "EPL-2.0",
       "dependencies": {
-        "ibm_db": "2.8.1"
+        "ibm_db": "2.8.2"
       },
       "devDependencies": {
         "@types/fs-extra": "^5.0.5",
@@ -3928,11 +3928,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/babel-jest": {
@@ -6660,9 +6660,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
       "funding": [
         {
           "type": "individual",
@@ -7250,12 +7250,12 @@
       }
     },
     "node_modules/ibm_db": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/ibm_db/-/ibm_db-2.8.1.tgz",
-      "integrity": "sha512-w4q5UN5FNRf4PW2yDG3uQVnA81vy2GS4vkGwigKgBuUMRa+pNgbAtTkhv3w/9Vz12X6YiYK9hFcwlVomKdj0qw==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/ibm_db/-/ibm_db-2.8.2.tgz",
+      "integrity": "sha512-cvvvz/VGeniQRHpSpiJmw2wJxkLG5ewcS1DLOW9rvHYBMBvyCM54O7ZhCSlsX1+XV5QKyKdvhjQxld+uoiZJlA==",
       "hasInstallScript": true,
       "dependencies": {
-        "axios": "^0.21.1",
+        "axios": "^0.26.1",
         "big-integer": "^1.6.51",
         "bindings": "^1.5.0",
         "fs-extra": "^8.1.0",
@@ -19414,11 +19414,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.8"
       }
     },
     "babel-jest": {
@@ -21521,9 +21521,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -21960,11 +21960,11 @@
       }
     },
     "ibm_db": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/ibm_db/-/ibm_db-2.8.1.tgz",
-      "integrity": "sha512-w4q5UN5FNRf4PW2yDG3uQVnA81vy2GS4vkGwigKgBuUMRa+pNgbAtTkhv3w/9Vz12X6YiYK9hFcwlVomKdj0qw==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/ibm_db/-/ibm_db-2.8.2.tgz",
+      "integrity": "sha512-cvvvz/VGeniQRHpSpiJmw2wJxkLG5ewcS1DLOW9rvHYBMBvyCM54O7ZhCSlsX1+XV5QKyKdvhjQxld+uoiZJlA==",
       "requires": {
-        "axios": "^0.21.1",
+        "axios": "^0.26.1",
         "big-integer": "^1.6.51",
         "bindings": "^1.5.0",
         "fs-extra": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "configurationModule": "lib/imperative.js"
   },
   "dependencies": {
-    "ibm_db": "2.8.1"
+    "ibm_db": "2.8.2"
   },
   "peerDependencies": {
     "@zowe/imperative": "^5.0.0"


### PR DESCRIPTION
As of version 2.8.2, Node.js 18 is supported (see https://github.com/ibmdb/node-ibm_db/commit/2a3205de89464369f31d1ee18d7556209e6ce320).

Although we don't officially support Node.js 18 until it becomes an LTS release, this PR should make the plug-in compatible 🙂 