### PR TITLE
Update the version of minimatch being distributed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 All notable changes to the IBM® Db2® Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Updated the version of minimatch
+
 ## `4.1.7`
 
 - BugFix: Updated ibm_db dependency to be compatible with Node.js 18
 
 ## `4.1.6`
 
-- BugFix: Update ibm_db to allow the plugin to install on M1 Macs.
+- BugFix: Updated ibm_db to allow the plugin to install on M1 Macs.
 
 ## `4.1.5`
 


### PR DESCRIPTION
There are some changes on the v1 LTS branch that have not been included in releases. One of which is to update a version of minimatch. That fix should be in the Zowe release with the code freeze, but is not because it was never published.

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>