### PR TITLE
Update readme documentation with reinstall note

### DIFF
--- a/.github/workflows/zowe-cli-plugin.yml
+++ b/.github/workflows/zowe-cli-plugin.yml
@@ -35,6 +35,12 @@ jobs:
       if: ${{ matrix.node-version == '14.x' }}
       run: npm install -g npm@7
 
+    - name: Update Python
+      if: ${{ matrix.node-version == '14.x' }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
     - name: Install Node Package Dependencies
       run: npm ci --quiet
 

--- a/.github/workflows/zowe-cli-plugin.yml
+++ b/.github/workflows/zowe-cli-plugin.yml
@@ -36,7 +36,7 @@ jobs:
       run: npm install -g npm@7
 
     - name: Update Python
-      if: ${{ matrix.node-version == '14.x' }}
+      if: ${{ matrix.node-version == '14.x' && matrix.os == 'macos-latest' }}
       uses: actions/setup-python@v4
       with:
         python-version: '3.10'

--- a/.github/workflows/zowe-cli-plugin.yml
+++ b/.github/workflows/zowe-cli-plugin.yml
@@ -36,7 +36,7 @@ jobs:
       run: npm install -g npm@7
 
     - name: Install Node Package Dependencies
-      run: npm ci
+      run: npm ci --quiet
 
     - name: Update Dependencies
       id: npm-update

--- a/README.md
+++ b/README.md
@@ -37,11 +37,7 @@ Before you install and use the plug-in:
 
 - **(Linux only - CentOS, RHEL)** Download and Install the following via yum: `python3 make gcc-c++`
 
-- Note: Reinstallation is required when Node is upgraded to a new major version. When installed, the plug-in builds a native binary that is needed to interact with Db2. If a new major version of Node is installed, you must uninstall and reinstall the IBM Db2 Database Plug-in to update the binary. Carry out this reinstallation if you encounter the following error:
-
-    ```
-    The module 'C:\Users\User\.zowe\plugins\installed\node_modules\@zowe\db2-for-zowe-cli\node_modules\ibm_db\build\Release\odbc_bindings.node' was compiled against a different Node.js version using NODE_MODULE_VERSION ###. This version of Node.js requires NODE_MODULE_VERSION ###. Please try re-compiling or re-installing this module (for instance, using npm rebuild or npm install).
-    ```
+- Note: Reinstallation is required when Node is upgraded to a new major version. When installed, the plug-in builds a native binary that is needed to interact with Db2. If a new major version of Node is installed, you must uninstall and reinstall the IBM Db2 Database Plug-in to update the binary. 
 
 ## Installing
 
@@ -150,6 +146,17 @@ Any failures potentially indicate an issue with the set-up of the Rest API or co
     zowe plugins uninstall @zowe/db2-for-zowe-cli
     ```
 After the uninstallation process completes successfully, the product no longer contains the plug-in configuration.
+
+## Troubleshooting
+
+### The IBM Db2 Database Plug-in for Zowe CLI is no longer compatible with the installed Node.js version.
+
+**Error message**:
+```
+The module 'C:\Users\User\.zowe\plugins\installed\node_modules\@zowe\db2-for-zowe-cli\node_modules\ibm_db\build\Release\odbc_bindings.node' was compiled against a different Node.js version using NODE_MODULE_VERSION ###. This version of Node.js requires NODE_MODULE_VERSION ###. Please try re-compiling or re-installing this module (for instance, using npm rebuild or npm install).
+```
+
+**Action**: The Node version installed on the system has changed since the IBM Db2 Database Plug-in for Zowe CLI was installed on the system, and the native binary is no longer compatible. Uninstall and reinstall the IBM Db2 Database Plug-in for Zowe CLI.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Before you install and use the plug-in:
 
 - **(Linux only - CentOS, RHEL)** Download and Install the following via yum: `python3 make gcc-c++`
 
-- This plug-in builds a native binary at install time that is required to interact with Db2. In the event that a new major version of Node is installed, it is required to uninstall and reinstall this plug-in to update the native binary. This step will need to be taken if you encounter the following error:
+- Note: Reinstallation is required when Node is upgraded to a new major version. When installed, the plug-in builds a native binary that is needed to interact with Db2. If a new major version of Node is installed, you must uninstall and reinstall the IBM Db2 Database Plug-in to update the binary. Carry out this reinstallation if you encounter the following error:
 
     ```
     The module 'C:\Users\User\.zowe\plugins\installed\node_modules\@zowe\db2-for-zowe-cli\node_modules\ibm_db\build\Release\odbc_bindings.node' was compiled against a different Node.js version using NODE_MODULE_VERSION ###. This version of Node.js requires NODE_MODULE_VERSION ###. Please try re-compiling or re-installing this module (for instance, using npm rebuild or npm install).

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Any failures potentially indicate an issue with the set-up of the Rest API or co
     ```
     zowe plugins uninstall @zowe/db2-for-zowe-cli
     ```
+2. **Windows Only** - The plug-in may encounter an error while uninstalling. If this occurs, run the uninstall command again.
+
 After the uninstallation process completes successfully, the product no longer contains the plug-in configuration.
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -149,14 +149,14 @@ After the uninstallation process completes successfully, the product no longer c
 
 ## Troubleshooting
 
-### The IBM Db2 Database Plug-in for Zowe CLI is no longer compatible with the installed Node.js version.
+### Node.js version incompatible with plug-in
 
 **Error message**:
 ```
 The module 'C:\Users\User\.zowe\plugins\installed\node_modules\@zowe\db2-for-zowe-cli\node_modules\ibm_db\build\Release\odbc_bindings.node' was compiled against a different Node.js version using NODE_MODULE_VERSION ###. This version of Node.js requires NODE_MODULE_VERSION ###. Please try re-compiling or re-installing this module (for instance, using npm rebuild or npm install).
 ```
 
-**Action**: The Node version installed on the system has changed since the IBM Db2 Database Plug-in for Zowe CLI was installed on the system, and the native binary is no longer compatible. Uninstall and reinstall the IBM Db2 Database Plug-in for Zowe CLI.
+**Action**: Uninstall and reinstall the IBM Db2 Database Plug-in for Zowe CLI. The Node version installed on the system has changed since the IBM Db2 Database Plug-in for Zowe CLI was installed on the system, and the native binary is no longer compatible.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Before you install and use the plug-in:
 
 - **(Linux only - CentOS, RHEL)** Download and Install the following via yum: `python3 make gcc-c++`
 
+- This plug-in builds a native binary at install time that is required to interact with Db2. In the event that a new major version of Node is installed, it is required to uninstall and reinstall this plug-in to update the native binary. This step will need to be taken if you encounter the following error:
+
+    ```
+    The module 'C:\Users\User\.zowe\plugins\installed\node_modules\@zowe\db2-for-zowe-cli\node_modules\ibm_db\build\Release\odbc_bindings.node' was compiled against a different Node.js version using NODE_MODULE_VERSION ###. This version of Node.js requires NODE_MODULE_VERSION ###. Please try re-compiling or re-installing this module (for instance, using npm rebuild or npm install).
+    ```
+
 ## Installing
 
 Use one of the following methods to install the plug-in:


### PR DESCRIPTION
Update documentation to reflect the need to reinstall the Db2 plug-in when updating Node.js on a system. Reviews and critiques are appreciated, because this information will also need to be reflected in the docs site.

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>