### PR TITLE
Fix junit and jest-stare output in wrong folder

### DIFF
--- a/__tests__/__resources__/env/system.env
+++ b/__tests__/__resources__/env/system.env
@@ -3,6 +3,6 @@
 JEST_STARE_RESULT_DIR=__tests__/__results__/system/jest-stare
 JEST_HTML_REPORTER_OUTPUT_PATH=__tests__/__results__/system/jest_html_reporter.html
 JEST_HTML_REPORTER_PAGE_TITLE="DB2 Plugin System and Integration Tests"
-JEST_JUNIT_OUTPUT=__tests__/__results__/system/junit.xml
+JEST_JUNIT_OUTPUT_DIR=__tests__/__results__/system
 JEST_SUITE_NAME="DB2 Plugin System and Integration Tests"
 JEST_JUNIT_SUITE_NAME="DB2 Plugin System and Integration Tests"

--- a/__tests__/__resources__/env/unit.env
+++ b/__tests__/__resources__/env/unit.env
@@ -4,6 +4,6 @@ JEST_STARE_RESULT_DIR=__tests__/__results__/unit/jest-stare
 JEST_STARE_COVERAGE_LINK=../../coverage/lcov-report/index.html
 JEST_HTML_REPORTER_OUTPUT_PATH=__tests__/__results__/unit/jest_html_reporter.html
 JEST_HTML_REPORTER_PAGE_TITLE="DB2 Plugin Unit Tests"
-JEST_JUNIT_OUTPUT=__tests__/__results__/unit/junit.xml
+JEST_JUNIT_OUTPUT_DIR=__tests__/__results__/unit
 JEST_SUITE_NAME="DB2 Plugin Unit Tests"
 JEST_JUNIT_SUITE_NAME="DB2 Plugin Unit Tests"

--- a/package.json
+++ b/package.json
@@ -115,13 +115,6 @@
         }
       ],
       [
-        "jest-stare",
-        {
-          "coverageLink": "../coverage/lcov-report/index.html",
-          "resultDir": "__tests__/__results__/jest-stare"
-        }
-      ],
-      [
         "jest-html-reporter",
         {
           "pageTitle": "DB2 Plugin Test Results",
@@ -136,5 +129,13 @@
         }
       ]
     ]
+  },
+  "jest-stare": {
+    "additionalResultsProcessors": [
+      "jest-junit",
+      "jest-html-reporter"
+    ],
+    "coverageLink": "../coverage/lcov-report/index.html",
+    "resultDir": "__tests__/__results__/jest-stare"
   }
 }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Typically the `__tests__/__results__` directory is structured like the following for unit test results:
```
__tests__
 |- __results__
     |- unit
        |- coverage
        |- jest-stare
        |- junit.xml
```

This PR fixes `jest-stare` folder being duplicated and `junit.xml` file being at wrong level:
```
__tests__
 |- __results__
     |- jest-stare
     |- unit
        |- coverage
        |- jest-stare
     |- junit.xml
```

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
Once this PR and related ones for other plug-ins are merged, the [Zowe CLI Coverage](https://github.com/zowe/zowe-cli-standalone-package/actions/workflows/zowe-cli-coverage.yaml) workflow should start passing again 😋 