### PR TITLE
Fix offline installation requirement of an undocumented env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® Db2® Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Updated the `ibm_db` dependency to fix an issue with offline installation. []()
+
 ## `6.1.4`
 
 - BugFix: Updated the `tar-fs` dependency for technical currency. [#178](https://github.com/zowe/zowe-cli-db2-plugin/pull/178)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the IBM® Db2® Plug-in for Zowe CLI will be documented i
 
 ## Recent Changes
 
-- BugFix: Updated the `ibm_db` dependency to fix an issue with offline installation. [#182](https://github.com/zowe/zowe-cli-db2-plugin/pull/182)
+- BugFix: Updated the `ibm_db` dependency to fix an issue with offline installation. [#183](https://github.com/zowe/zowe-cli-db2-plugin/issues/183)
 
 ## `6.1.4`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the IBM® Db2® Plug-in for Zowe CLI will be documented i
 
 ## Recent Changes
 
-- BugFix: Updated the `ibm_db` dependency to fix an issue with offline installation. []()
+- BugFix: Updated the `ibm_db` dependency to fix an issue with offline installation. [#182](https://github.com/zowe/zowe-cli-db2-plugin/pull/182)
 
 ## `6.1.4`
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
       "version": "6.1.4",
       "license": "EPL-2.0",
       "dependencies": {
-        "ibm_db": "3.3.0"
+        "ibm_db": "3.3.1"
       },
       "devDependencies": {
         "@types/ibm_db": "^2.0.16",
@@ -5282,9 +5282,9 @@
       }
     },
     "node_modules/ibm_db": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ibm_db/-/ibm_db-3.3.0.tgz",
-      "integrity": "sha512-hQpbM/iIpIRSU3SjMyY25hGMfTGVqDoON3g2p7oFVk5Px9XX12F4iODJG27CEa+tnm0a9ArVGyQ9ZhS0FLhyXw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ibm_db/-/ibm_db-3.3.1.tgz",
+      "integrity": "sha512-wcbZY3coJoRYM1eUUYvlrhT78CXV7f5cVSdfeWIZXyJ2Imuq+sHQQgc7nEwDXeauwOlvlSVu1MysFjFzrWQg0A==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -5294,7 +5294,7 @@
         "bindings": "^1.5.0",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
-        "nan": "^2.22.0",
+        "nan": "^2.22.2",
         "q": "^1.5.1",
         "targz": "^1.0.1"
       },
@@ -7276,9 +7276,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
-      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
+      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
       "license": "MIT"
     },
     "node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "configurationModule": "lib/imperative.js"
   },
   "dependencies": {
-    "ibm_db": "3.3.0"
+    "ibm_db": "3.3.1"
   },
   "peerDependencies": {
     "@zowe/imperative": "^8.0.0"


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Removes the requirement to set an undocumented environment variable when installing the DB2 plug-in offline.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Attempt to perform an offline installation of the current DB2 plug-in, with an offline copy of the DB2 CLI driver. Note that an undocumented environment variable, `npm_config_clidriver`, needs to be set to perform the action.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->