### PR TITLE
Add proper escaping of single quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® Db2® Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Added proper escaping of single quotes in string values returned by the `export table` command. [#207](https://github.com/zowe/zowe-cli-db2-plugin/pull/207)
+
 ## `6.1.15`
 
 - BugFix: Updated the `form-data` dependency for technical currency. [#205](https://github.com/zowe/zowe-cli-db2-plugin/pull/205)

--- a/__tests__/api/ExportTableSQL.test.ts
+++ b/__tests__/api/ExportTableSQL.test.ts
@@ -55,6 +55,11 @@ describe("ExportTable", () => {
         it("should return value as is for other types", () => {
             expect(exportSQL.escape("I", C.ROWS[0].I)).toBe(C.ROWS[0].I);
         });
+
+        it("should escape quotes for string value", () => {
+            const valWithQuotes = C.ROWS[0].V + "'TEST";
+            expect(exportSQL.escape("V", valWithQuotes)).toBe(`'${C.ROWS[0].V}''TEST'`);
+        });
     });
 
     describe("buildInsertStatement", () => {

--- a/src/api/ExportTableSQL.ts
+++ b/src/api/ExportTableSQL.ts
@@ -81,7 +81,7 @@ export class ExportTableSQL extends ExportTable {
             case "TIME":
             case "TIMESTAMP":
             case "VARCHAR":
-                return `'${value.replace(/'/g, "''")}'`;
+                return `'${value.replaceAll("'", "''")}'`;
             default:
                 return value;
         }

--- a/src/api/ExportTableSQL.ts
+++ b/src/api/ExportTableSQL.ts
@@ -81,7 +81,7 @@ export class ExportTableSQL extends ExportTable {
             case "TIME":
             case "TIMESTAMP":
             case "VARCHAR":
-                return `'${value}'`;
+                return `'${value.replace(/'/g, "''")}'`;
             default:
                 return value;
         }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Escapes single quotes in string values returned by the `export table` command. This conforms to SQL standard as mentioned here (the official version is behind a paywall): https://stackoverflow.com/a/58138810/5504760

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->