### PR TITLE
DRAFT: feat: add alternative JDBC driver pathway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ __tests__/__results__/
 !/__tests__/__resources__/properties/example_properties.yaml
 package-lock.json
 docs/typedoc/
+zowe.config.yaml
+zowe.config.user.yaml
+zowe.config.json
+zowe.config.user.json
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® Db2® Plug-in for Zowe CLI will be documented in this file.
 
+## `6.1.17`
+
+- Enhancement: Added an alternative JDBC driver pathway (`--driver-type jdbc`) allowing users without an ODBC license key to connect using `db2jcc4.jar` and `db2jcc_license_cisuz.jar`.
+
 ## `6.1.16`
 
 - BugFix: Added proper escaping of single quotes in string values returned by the `export table` command. [#207](https://github.com/zowe/zowe-cli-db2-plugin/pull/207)

--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ Before you install and use the plug-in:
 
 -   [Install Zowe CLI](https://docs.zowe.org/stable/user-guide/cli-installcli.html) on your computer.
 
--   Have a license file for IBM Db2 Database for z/OS.
+-   Have a license for IBM Db2 Database for z/OS.
 
-    For connectivity to Db2 for z/OS, the Db2 region should be `db2connectactivated` or a `db2connect` license file should be provided. Copy the `db2connect` license file to the `[db2 plugin folder]/node_modules/ibm_db/installer/clidriver/license/` folder. For more information, see [Addressing the license requirement](https://docs.zowe.org/stable/user-guide/cli-db2plugin.html#addressing-the-license-requirement) on the Zowe Docs site. 
+    For connectivity to Db2 for z/OS:
+    - **ODBC Driver (Default)**: The Db2 region should be `db2connectactivated` or a `db2connect` license file (`db2consv_zs.lic`) should be provided in `[db2 plugin folder]/node_modules/ibm_db/installer/clidriver/license/`.
+    - **JDBC Driver (Alternative Pathway)**: If you do not have an ODBC license key, you can alternatively use the Db2 JDBC driver (`db2jcc4.jar`) and JDBC license JAR (`db2jcc_license_cisuz.jar`). Set `driverType` to `jdbc` in your Db2 profile or pass `--driver-type jdbc`, and specify `--jdbc-jar` and `--jdbc-license` paths. Java runtime (`java`) is required on your PATH.
+
 
 - **(Linux and MacOS only)** Download and install [node-gyp](https://www.npmjs.com/package/node-gyp) globally by running `npm install -g node-gyp`
 

--- a/__tests__/__integration__/__scripts__/call_typesmap_datetime.sh
+++ b/__tests__/__integration__/__scripts__/call_typesmap_datetime.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+zowe db2 call stored-proc "TYPESMAP" \
+  --parameters '[
+    {"ParamType":"INPUT","Data":"","DataType":1},
+    {"ParamType":"INPUT","Data":"","DataType":12},
+    {"ParamType":"INPUT","Data":0,"DataType":5},
+    {"ParamType":"INPUT","Data":0,"DataType":4},
+    {"ParamType":"INPUT","Data":0,"DataType":-5},
+    {"ParamType":"INPUT","Data":0,"DataType":3},
+    {"ParamType":"INPUT","Data":0,"DataType":7},
+    {"ParamType":"INPUT","Data":0,"DataType":8},
+    {"ParamType":"INPUT","Data":"2024-06-15","DataType":91},
+    {"ParamType":"INPUT","Data":"13:30:00","DataType":92},
+    {"ParamType":"INPUT","Data":"2024-06-15 13:30:00","DataType":93},
+    {"ParamType":"OUTPUT","Data":null,"DataType":1},
+    {"ParamType":"OUTPUT","Data":null,"DataType":12},
+    {"ParamType":"OUTPUT","Data":null,"DataType":5},
+    {"ParamType":"OUTPUT","Data":null,"DataType":4},
+    {"ParamType":"OUTPUT","Data":null,"DataType":-5},
+    {"ParamType":"OUTPUT","Data":null,"DataType":3},
+    {"ParamType":"OUTPUT","Data":null,"DataType":7},
+    {"ParamType":"OUTPUT","Data":null,"DataType":8},
+    {"ParamType":"OUTPUT","Data":null,"DataType":91},
+    {"ParamType":"OUTPUT","Data":null,"DataType":92},
+    {"ParamType":"OUTPUT","Data":null,"DataType":93}
+  ]' --rfj \
+  | node -e "process.stdin.resume(); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ const r=JSON.parse(d); if(!r.success){process.stderr.write(r.stderr||r.message||'failed'); process.exit(1);} console.log(JSON.stringify(r.data)); })"

--- a/__tests__/__integration__/__scripts__/call_typesmap_datetime.sh
+++ b/__tests__/__integration__/__scripts__/call_typesmap_datetime.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
 set -e
-zowe db2 call stored-proc "TYPESMAP" \
-  --parameters '[
-    {"ParamType":"INPUT","Data":"","DataType":1},
-    {"ParamType":"INPUT","Data":"","DataType":12},
-    {"ParamType":"INPUT","Data":0,"DataType":5},
-    {"ParamType":"INPUT","Data":0,"DataType":4},
-    {"ParamType":"INPUT","Data":0,"DataType":-5},
-    {"ParamType":"INPUT","Data":0,"DataType":3},
-    {"ParamType":"INPUT","Data":0,"DataType":7},
-    {"ParamType":"INPUT","Data":0,"DataType":8},
-    {"ParamType":"INPUT","Data":"2024-06-15","DataType":91},
-    {"ParamType":"INPUT","Data":"13:30:00","DataType":92},
-    {"ParamType":"INPUT","Data":"2024-06-15 13:30:00","DataType":93},
-    {"ParamType":"OUTPUT","Data":null,"DataType":1},
-    {"ParamType":"OUTPUT","Data":null,"DataType":12},
-    {"ParamType":"OUTPUT","Data":null,"DataType":5},
-    {"ParamType":"OUTPUT","Data":null,"DataType":4},
-    {"ParamType":"OUTPUT","Data":null,"DataType":-5},
-    {"ParamType":"OUTPUT","Data":null,"DataType":3},
-    {"ParamType":"OUTPUT","Data":null,"DataType":7},
-    {"ParamType":"OUTPUT","Data":null,"DataType":8},
-    {"ParamType":"OUTPUT","Data":null,"DataType":91},
-    {"ParamType":"OUTPUT","Data":null,"DataType":92},
-    {"ParamType":"OUTPUT","Data":null,"DataType":93}
-  ]' --rfj \
+zowe db2 call procedure "TYPESMAP" \
+  --parameters \
+    '{"ParamType":"INPUT","Data":"","DataType":1}' \
+    '{"ParamType":"INPUT","Data":"","DataType":12}' \
+    '{"ParamType":"INPUT","Data":0,"DataType":5}' \
+    '{"ParamType":"INPUT","Data":0,"DataType":4}' \
+    '{"ParamType":"INPUT","Data":0,"DataType":-5}' \
+    '{"ParamType":"INPUT","Data":0,"DataType":3}' \
+    '{"ParamType":"INPUT","Data":0,"DataType":7}' \
+    '{"ParamType":"INPUT","Data":0,"DataType":8}' \
+    '{"ParamType":"INPUT","Data":"2024-06-15","DataType":91}' \
+    '{"ParamType":"INPUT","Data":"13:30:00","DataType":92}' \
+    '{"ParamType":"INPUT","Data":"2024-06-15 13:30:00","DataType":93}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":1}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":12}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":5}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":4}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":-5}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":3}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":7}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":8}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":91}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":92}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":93}' \
+  --rfj \
   | node -e "process.stdin.resume(); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ const r=JSON.parse(d); if(!r.success){process.stderr.write(r.stderr||r.message||'failed'); process.exit(1);} console.log(JSON.stringify(r.data)); })"

--- a/__tests__/__integration__/__scripts__/call_typesmap_numerics.sh
+++ b/__tests__/__integration__/__scripts__/call_typesmap_numerics.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+zowe db2 call stored-proc "TYPESMAP" \
+  --parameters '[
+    {"ParamType":"INPUT","Data":"","DataType":1},
+    {"ParamType":"INPUT","Data":"","DataType":12},
+    {"ParamType":"INPUT","Data":1,"DataType":5},
+    {"ParamType":"INPUT","Data":42,"DataType":4},
+    {"ParamType":"INPUT","Data":9999999999,"DataType":-5},
+    {"ParamType":"INPUT","Data":3.14,"DataType":3},
+    {"ParamType":"INPUT","Data":2.5,"DataType":7},
+    {"ParamType":"INPUT","Data":1.23456789,"DataType":8},
+    {"ParamType":"INPUT","Data":"2000-01-01","DataType":91},
+    {"ParamType":"INPUT","Data":"00:00:00","DataType":92},
+    {"ParamType":"INPUT","Data":"2000-01-01 00:00:00","DataType":93},
+    {"ParamType":"OUTPUT","Data":null,"DataType":1},
+    {"ParamType":"OUTPUT","Data":null,"DataType":12},
+    {"ParamType":"OUTPUT","Data":null,"DataType":5},
+    {"ParamType":"OUTPUT","Data":null,"DataType":4},
+    {"ParamType":"OUTPUT","Data":null,"DataType":-5},
+    {"ParamType":"OUTPUT","Data":null,"DataType":3},
+    {"ParamType":"OUTPUT","Data":null,"DataType":7},
+    {"ParamType":"OUTPUT","Data":null,"DataType":8}
+  ]' --rfj \
+  | node -e "process.stdin.resume(); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ const r=JSON.parse(d); if(!r.success){process.stderr.write(r.stderr||r.message||'failed'); process.exit(1);} console.log(JSON.stringify(r.data)); })"

--- a/__tests__/__integration__/__scripts__/call_typesmap_numerics.sh
+++ b/__tests__/__integration__/__scripts__/call_typesmap_numerics.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
 set -e
-zowe db2 call stored-proc "TYPESMAP" \
-  --parameters '[
-    {"ParamType":"INPUT","Data":"","DataType":1},
-    {"ParamType":"INPUT","Data":"","DataType":12},
-    {"ParamType":"INPUT","Data":1,"DataType":5},
-    {"ParamType":"INPUT","Data":42,"DataType":4},
-    {"ParamType":"INPUT","Data":9999999999,"DataType":-5},
-    {"ParamType":"INPUT","Data":3.14,"DataType":3},
-    {"ParamType":"INPUT","Data":2.5,"DataType":7},
-    {"ParamType":"INPUT","Data":1.23456789,"DataType":8},
-    {"ParamType":"INPUT","Data":"2000-01-01","DataType":91},
-    {"ParamType":"INPUT","Data":"00:00:00","DataType":92},
-    {"ParamType":"INPUT","Data":"2000-01-01 00:00:00","DataType":93},
-    {"ParamType":"OUTPUT","Data":null,"DataType":1},
-    {"ParamType":"OUTPUT","Data":null,"DataType":12},
-    {"ParamType":"OUTPUT","Data":null,"DataType":5},
-    {"ParamType":"OUTPUT","Data":null,"DataType":4},
-    {"ParamType":"OUTPUT","Data":null,"DataType":-5},
-    {"ParamType":"OUTPUT","Data":null,"DataType":3},
-    {"ParamType":"OUTPUT","Data":null,"DataType":7},
-    {"ParamType":"OUTPUT","Data":null,"DataType":8}
-  ]' --rfj \
+zowe db2 call procedure "TYPESMAP" \
+  --parameters \
+    '{"ParamType":"INPUT","Data":"","DataType":1}' \
+    '{"ParamType":"INPUT","Data":"","DataType":12}' \
+    '{"ParamType":"INPUT","Data":1,"DataType":5}' \
+    '{"ParamType":"INPUT","Data":42,"DataType":4}' \
+    '{"ParamType":"INPUT","Data":9999999999,"DataType":-5}' \
+    '{"ParamType":"INPUT","Data":3.14,"DataType":3}' \
+    '{"ParamType":"INPUT","Data":2.5,"DataType":7}' \
+    '{"ParamType":"INPUT","Data":1.23456789,"DataType":8}' \
+    '{"ParamType":"INPUT","Data":"2000-01-01","DataType":91}' \
+    '{"ParamType":"INPUT","Data":"00:00:00","DataType":92}' \
+    '{"ParamType":"INPUT","Data":"2000-01-01 00:00:00","DataType":93}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":1}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":12}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":5}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":4}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":-5}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":3}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":7}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":8}' \
+  --rfj \
   | node -e "process.stdin.resume(); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ const r=JSON.parse(d); if(!r.success){process.stderr.write(r.stderr||r.message||'failed'); process.exit(1);} console.log(JSON.stringify(r.data)); })"

--- a/__tests__/__integration__/__scripts__/call_typesmap_strings.sh
+++ b/__tests__/__integration__/__scripts__/call_typesmap_strings.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 set -e
-zowe db2 call stored-proc "TYPESMAP" \
-  --parameters '[
-    {"ParamType":"INPUT","Data":"hello","DataType":1},
-    {"ParamType":"INPUT","Data":"world","DataType":12},
-    {"ParamType":"INPUT","Data":0,"DataType":5},
-    {"ParamType":"INPUT","Data":0,"DataType":4},
-    {"ParamType":"INPUT","Data":0,"DataType":-5},
-    {"ParamType":"INPUT","Data":0,"DataType":3},
-    {"ParamType":"INPUT","Data":0,"DataType":7},
-    {"ParamType":"INPUT","Data":0,"DataType":8},
-    {"ParamType":"INPUT","Data":"2000-01-01","DataType":91},
-    {"ParamType":"INPUT","Data":"00:00:00","DataType":92},
-    {"ParamType":"INPUT","Data":"2000-01-01 00:00:00","DataType":93},
-    {"ParamType":"OUTPUT","Data":null,"DataType":1},
-    {"ParamType":"OUTPUT","Data":null,"DataType":12}
-  ]' --rfj \
+zowe db2 call procedure "TYPESMAP" \
+  --parameters \
+    '{"ParamType":"INPUT","Data":"hello","DataType":1}' \
+    '{"ParamType":"INPUT","Data":"world","DataType":12}' \
+    '{"ParamType":"INPUT","Data":0,"DataType":5}' \
+    '{"ParamType":"INPUT","Data":0,"DataType":4}' \
+    '{"ParamType":"INPUT","Data":0,"DataType":-5}' \
+    '{"ParamType":"INPUT","Data":0,"DataType":3}' \
+    '{"ParamType":"INPUT","Data":0,"DataType":7}' \
+    '{"ParamType":"INPUT","Data":0,"DataType":8}' \
+    '{"ParamType":"INPUT","Data":"2000-01-01","DataType":91}' \
+    '{"ParamType":"INPUT","Data":"00:00:00","DataType":92}' \
+    '{"ParamType":"INPUT","Data":"2000-01-01 00:00:00","DataType":93}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":1}' \
+    '{"ParamType":"OUTPUT","Data":null,"DataType":12}' \
+  --rfj \
   | node -e "process.stdin.resume(); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ const r=JSON.parse(d); if(!r.success){process.stderr.write(r.stderr||r.message||'failed'); process.exit(1);} console.log(JSON.stringify(r.data)); })"

--- a/__tests__/__integration__/__scripts__/call_typesmap_strings.sh
+++ b/__tests__/__integration__/__scripts__/call_typesmap_strings.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+zowe db2 call stored-proc "TYPESMAP" \
+  --parameters '[
+    {"ParamType":"INPUT","Data":"hello","DataType":1},
+    {"ParamType":"INPUT","Data":"world","DataType":12},
+    {"ParamType":"INPUT","Data":0,"DataType":5},
+    {"ParamType":"INPUT","Data":0,"DataType":4},
+    {"ParamType":"INPUT","Data":0,"DataType":-5},
+    {"ParamType":"INPUT","Data":0,"DataType":3},
+    {"ParamType":"INPUT","Data":0,"DataType":7},
+    {"ParamType":"INPUT","Data":0,"DataType":8},
+    {"ParamType":"INPUT","Data":"2000-01-01","DataType":91},
+    {"ParamType":"INPUT","Data":"00:00:00","DataType":92},
+    {"ParamType":"INPUT","Data":"2000-01-01 00:00:00","DataType":93},
+    {"ParamType":"OUTPUT","Data":null,"DataType":1},
+    {"ParamType":"OUTPUT","Data":null,"DataType":12}
+  ]' --rfj \
+  | node -e "process.stdin.resume(); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ const r=JSON.parse(d); if(!r.success){process.stderr.write(r.stderr||r.message||'failed'); process.exit(1);} console.log(JSON.stringify(r.data)); })"

--- a/__tests__/__integration__/__scripts__/execute_badsql.sh
+++ b/__tests__/__integration__/__scripts__/execute_badsql.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+zowe db2 execute sql --query "SELEKT 1 FROM SYSIBM.SYSDUMMY1"
+exit $?

--- a/__tests__/__integration__/__scripts__/execute_datetime.sh
+++ b/__tests__/__integration__/__scripts__/execute_datetime.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
-zowe db2 execute sql --query "VALUES (CURRENT DATE AS D, CURRENT TIME AS T, CURRENT TIMESTAMP AS TS)" --rfj \
+zowe db2 execute sql --query "SELECT CURRENT DATE AS D, CURRENT TIME AS T, CURRENT TIMESTAMP AS TS FROM SYSIBM.SYSDUMMY1" --rfj \
   | node -e "process.stdin.resume(); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ const r=JSON.parse(d); if(!r.success){process.stderr.write(r.stderr||r.message||'failed'); process.exit(1);} console.log(JSON.stringify(r.data)); })"

--- a/__tests__/__integration__/__scripts__/execute_datetime.sh
+++ b/__tests__/__integration__/__scripts__/execute_datetime.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+zowe db2 execute sql --query "VALUES (CURRENT DATE AS D, CURRENT TIME AS T, CURRENT TIMESTAMP AS TS)" --rfj \
+  | node -e "process.stdin.resume(); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ const r=JSON.parse(d); if(!r.success){process.stderr.write(r.stderr||r.message||'failed'); process.exit(1);} console.log(JSON.stringify(r.data)); })"

--- a/__tests__/__integration__/__scripts__/execute_inline.sh
+++ b/__tests__/__integration__/__scripts__/execute_inline.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Execute a SQL statement passed as $1. Used for setup/teardown.
+# Ignores errors (e.g. DROP when proc doesn't exist).
+zowe db2 execute sql --query "$1" 2>/dev/null || true

--- a/__tests__/__integration__/__scripts__/execute_norows.sh
+++ b/__tests__/__integration__/__scripts__/execute_norows.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+zowe db2 execute sql --query "SELECT * FROM SYSIBM.SYSTABLES WHERE NAME='ZZZNOMATCH_XYZ'" --rfj \
+  | node -e "process.stdin.resume(); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ const r=JSON.parse(d); if(!r.success){process.stderr.write(r.stderr||r.message||'failed'); process.exit(1);} console.log(JSON.stringify(r.data)); })"

--- a/__tests__/__integration__/__scripts__/execute_numerics.sh
+++ b/__tests__/__integration__/__scripts__/execute_numerics.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+zowe db2 execute sql --query "VALUES (CAST(1 AS SMALLINT) AS SI, CAST(42 AS INTEGER) AS I, CAST(9999999999 AS BIGINT) AS BI, CAST(3.14 AS DECIMAL(5,2)) AS D, CAST(2.5 AS REAL) AS R, CAST(1.23456789 AS DOUBLE) AS DB)" --rfj \
+  | node -e "process.stdin.resume(); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ const r=JSON.parse(d); if(!r.success){process.stderr.write(r.stderr||r.message||'failed'); process.exit(1);} console.log(JSON.stringify(r.data)); })"

--- a/__tests__/__integration__/__scripts__/execute_numerics.sh
+++ b/__tests__/__integration__/__scripts__/execute_numerics.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
-zowe db2 execute sql --query "VALUES (CAST(1 AS SMALLINT) AS SI, CAST(42 AS INTEGER) AS I, CAST(9999999999 AS BIGINT) AS BI, CAST(3.14 AS DECIMAL(5,2)) AS D, CAST(2.5 AS REAL) AS R, CAST(1.23456789 AS DOUBLE) AS DB)" --rfj \
+zowe db2 execute sql --query "SELECT CAST(1 AS SMALLINT) AS SI, CAST(42 AS INTEGER) AS I, CAST(9999999999 AS BIGINT) AS BI, CAST(3.14 AS DECIMAL(5,2)) AS D, CAST(2.5 AS REAL) AS R, CAST(1.23456789 AS DOUBLE) AS DB FROM SYSIBM.SYSDUMMY1" --rfj \
   | node -e "process.stdin.resume(); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ const r=JSON.parse(d); if(!r.success){process.stderr.write(r.stderr||r.message||'failed'); process.exit(1);} console.log(JSON.stringify(r.data)); })"

--- a/__tests__/__integration__/__scripts__/execute_rowcount.sh
+++ b/__tests__/__integration__/__scripts__/execute_rowcount.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+zowe db2 execute sql --query "SELECT COUNT(*) AS CNT FROM SYSIBM.SYSTABLES" --rfj \
+  | node -e "process.stdin.resume(); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ const r=JSON.parse(d); if(!r.success){process.stderr.write(r.stderr||r.message||'failed'); process.exit(1);} console.log(JSON.stringify(r.data)); })"

--- a/__tests__/__integration__/__scripts__/execute_smoke.sh
+++ b/__tests__/__integration__/__scripts__/execute_smoke.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+zowe db2 execute sql --query "SELECT 1 AS ONE FROM SYSIBM.SYSDUMMY1" --rfj \
+  | node -e "process.stdin.resume(); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ const r=JSON.parse(d); if(!r.success){process.stderr.write(r.stderr||r.message||'failed'); process.exit(1);} console.log(JSON.stringify(r.data)); })"

--- a/__tests__/__integration__/__scripts__/execute_strings.sh
+++ b/__tests__/__integration__/__scripts__/execute_strings.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+zowe db2 execute sql --query "VALUES (CAST('hello' AS CHAR(20)) AS C, CAST('world' AS VARCHAR(20)) AS V)" --rfj \
+  | node -e "process.stdin.resume(); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ const r=JSON.parse(d); if(!r.success){process.stderr.write(r.stderr||r.message||'failed'); process.exit(1);} console.log(JSON.stringify(r.data)); })"

--- a/__tests__/__integration__/__scripts__/execute_strings.sh
+++ b/__tests__/__integration__/__scripts__/execute_strings.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
-zowe db2 execute sql --query "VALUES (CAST('hello' AS CHAR(20)) AS C, CAST('world' AS VARCHAR(20)) AS V)" --rfj \
+zowe db2 execute sql --query "SELECT CAST('hello' AS CHAR(20)) AS C, CAST('world' AS VARCHAR(20)) AS V FROM SYSIBM.SYSDUMMY1" --rfj \
   | node -e "process.stdin.resume(); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ const r=JSON.parse(d); if(!r.success){process.stderr.write(r.stderr||r.message||'failed'); process.exit(1);} console.log(JSON.stringify(r.data)); })"

--- a/__tests__/__integration__/db2.call.integration.test.ts
+++ b/__tests__/__integration__/db2.call.integration.test.ts
@@ -11,107 +11,115 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import { runCliScript } from "@zowe/cli-test-utils";
+import { ITestEnvironment, TestEnvironment, runCliScript } from "@zowe/cli-test-utils";
+import { IIntegrationTestProperties } from "./doc/IIntegrationTestProperties";
 
-// Integration tests require zowe.config.json at the project root (gitignored).
-// The entire suite is skipped when the file is absent so CI is unaffected.
-const CONFIG_PATH = path.resolve(__dirname, "../../zowe.config.json");
+// Skip the entire suite if custom_properties.yaml is absent (no live Db2 configured)
+const PROPS_PATH = path.resolve(__dirname, "../__resources__/properties/custom_properties.yaml");
+const describeOrSkip = fs.existsSync(PROPS_PATH) ? describe : describe.skip;
+
 const SCRIPTS = path.resolve(__dirname, "__scripts__");
 
-const CREATE_TYPESMAP = `
-CREATE PROCEDURE TYPESMAP (
-    IN  ICHAR        CHARACTER(20),
-    IN  IVARCHAR     VARCHAR(20),
-    IN  ISMALLINT    SMALLINT,
-    IN  IINTEGER     INTEGER,
-    IN  IBIGINT      BIGINT,
-    IN  IDECIMAL     DECIMAL(10,2),
-    IN  IREAL        REAL,
-    IN  IDOUBLE      DOUBLE,
-    IN  IDATE        DATE,
-    IN  ITIME        TIME,
-    IN  ITIMESTAMP   TIMESTAMP,
-    OUT OCHAR        CHARACTER(20),
-    OUT OVARCHAR     VARCHAR(20),
-    OUT OSMALLINT    SMALLINT,
-    OUT OINTEGER     INTEGER,
-    OUT OBIGINT      BIGINT,
-    OUT ODECIMAL     DECIMAL(10,2),
-    OUT OREAL        REAL,
-    OUT ODOUBLE      DOUBLE,
-    OUT ODATE        DATE,
-    OUT OTIME        TIME,
-    OUT OTIMESTAMP   TIMESTAMP
-) LANGUAGE SQL
-BEGIN
-    SET OCHAR      = ICHAR;
-    SET OVARCHAR   = IVARCHAR;
-    SET OSMALLINT  = ISMALLINT;
-    SET OINTEGER   = IINTEGER;
-    SET OBIGINT    = IBIGINT;
-    SET ODECIMAL   = IDECIMAL;
-    SET OREAL      = IREAL;
-    SET ODOUBLE    = IDOUBLE;
-    SET ODATE      = IDATE;
-    SET OTIME      = ITIME;
-    SET OTIMESTAMP = ITIMESTAMP;
-END
-`.trim();
+let TEST_ENV: ITestEnvironment<IIntegrationTestProperties>;
+
+const CREATE_TYPESMAP = [
+    "CREATE PROCEDURE TYPESMAP (",
+    "    IN  ICHAR        CHARACTER(20),",
+    "    IN  IVARCHAR     VARCHAR(20),",
+    "    IN  ISMALLINT    SMALLINT,",
+    "    IN  IINTEGER     INTEGER,",
+    "    IN  IBIGINT      BIGINT,",
+    "    IN  IDECIMAL     DECIMAL(10,2),",
+    "    IN  IREAL        REAL,",
+    "    IN  IDOUBLE      DOUBLE,",
+    "    IN  IDATE        DATE,",
+    "    IN  ITIME        TIME,",
+    "    IN  ITIMESTAMP   TIMESTAMP,",
+    "    OUT OCHAR        CHARACTER(20),",
+    "    OUT OVARCHAR     VARCHAR(20),",
+    "    OUT OSMALLINT    SMALLINT,",
+    "    OUT OINTEGER     INTEGER,",
+    "    OUT OBIGINT      BIGINT,",
+    "    OUT ODECIMAL     DECIMAL(10,2),",
+    "    OUT OREAL        REAL,",
+    "    OUT ODOUBLE      DOUBLE,",
+    "    OUT ODATE        DATE,",
+    "    OUT OTIME        TIME,",
+    "    OUT OTIMESTAMP   TIMESTAMP",
+    ") LANGUAGE SQL",
+    "BEGIN",
+    "    SET OCHAR      = ICHAR;",
+    "    SET OVARCHAR   = IVARCHAR;",
+    "    SET OSMALLINT  = ISMALLINT;",
+    "    SET OINTEGER   = IINTEGER;",
+    "    SET OBIGINT    = IBIGINT;",
+    "    SET ODECIMAL   = IDECIMAL;",
+    "    SET OREAL      = IREAL;",
+    "    SET ODOUBLE    = IDOUBLE;",
+    "    SET ODATE      = IDATE;",
+    "    SET OTIME      = ITIME;",
+    "    SET OTIMESTAMP = ITIMESTAMP;",
+    "END",
+].join(" ");
 
 const DROP_TYPESMAP = "DROP PROCEDURE TYPESMAP";
-
-const describeOrSkip = fs.existsSync(CONFIG_PATH) ? describe : describe.skip;
 
 describeOrSkip("db2 call stored-proc — integration (live Db2, TYPESMAP)", () => {
 
     beforeAll(async () => {
-        // Drop any leftover from a previous failed run, then create fresh
-        runCliScript(path.join(SCRIPTS, "execute_inline.sh"), process.cwd() as any, [DROP_TYPESMAP]);
-        const create = runCliScript(path.join(SCRIPTS, "execute_inline.sh"), process.cwd() as any, [CREATE_TYPESMAP]);
+        TEST_ENV = await TestEnvironment.setUp({
+            installPlugin: true,
+            tempProfileTypes: ["db2"],
+            testName: "integration_call",
+        });
+        // Drop any leftover from a previous failed run, ignore errors
+        runCliScript(path.join(SCRIPTS, "execute_inline.sh"), TEST_ENV, [DROP_TYPESMAP]);
+        // Create the type-mapping procedure under the current user's schema
+        const create = runCliScript(path.join(SCRIPTS, "execute_inline.sh"), TEST_ENV, [CREATE_TYPESMAP]);
         if (create.status !== 0) {
             throw new Error(`Failed to create TYPESMAP: ${create.stderr.toString()}`);
         }
     });
 
-    afterAll(() => {
-        runCliScript(path.join(SCRIPTS, "execute_inline.sh"), process.cwd() as any, [DROP_TYPESMAP]);
+    afterAll(async () => {
+        runCliScript(path.join(SCRIPTS, "execute_inline.sh"), TEST_ENV, [DROP_TYPESMAP]);
+        await TestEnvironment.cleanUp(TEST_ENV);
     });
 
     it("string OUT params round-trip (CHAR, VARCHAR)", () => {
-        const response = runCliScript(path.join(SCRIPTS, "call_typesmap_strings.sh"), process.cwd() as any);
+        const response = runCliScript(path.join(SCRIPTS, "call_typesmap_strings.sh"), TEST_ENV);
         expect(response.status).toBe(0);
         expect(response.stderr.toString()).toBe("");
         const data = JSON.parse(response.stdout.toString());
         expect(data.success).toBe(true);
-        // results array: OUT params come back as individual result entries
         const results: any[] = data.results;
         expect(results[0].trim()).toBe("hello");   // OCHAR
         expect(results[1]).toBe("world");           // OVARCHAR
     });
 
     it("numeric OUT params round-trip (SMALLINT, INTEGER, BIGINT, DECIMAL, REAL, DOUBLE)", () => {
-        const response = runCliScript(path.join(SCRIPTS, "call_typesmap_numerics.sh"), process.cwd() as any);
+        const response = runCliScript(path.join(SCRIPTS, "call_typesmap_numerics.sh"), TEST_ENV);
         expect(response.status).toBe(0);
         expect(response.stderr.toString()).toBe("");
         const data = JSON.parse(response.stdout.toString());
         expect(data.success).toBe(true);
         const results: any[] = data.results;
-        expect(Number(results[0])).toBe(1);          // OSMALLINT
-        expect(Number(results[1])).toBe(42);         // OINTEGER
-        expect(Number(results[2])).toBe(9999999999); // OBIGINT
+        expect(Number(results[0])).toBe(1);              // OSMALLINT
+        expect(Number(results[1])).toBe(42);             // OINTEGER
+        expect(Number(results[2])).toBe(9999999999);     // OBIGINT
         expect(Number(results[3])).toBeCloseTo(3.14, 1); // ODECIMAL
     });
 
     it("date/time OUT params round-trip (DATE, TIME, TIMESTAMP)", () => {
-        const response = runCliScript(path.join(SCRIPTS, "call_typesmap_datetime.sh"), process.cwd() as any);
+        const response = runCliScript(path.join(SCRIPTS, "call_typesmap_datetime.sh"), TEST_ENV);
         expect(response.status).toBe(0);
         expect(response.stderr.toString()).toBe("");
         const data = JSON.parse(response.stdout.toString());
         expect(data.success).toBe(true);
         const results: any[] = data.results;
-        expect(results[0]).toMatch(/^\d{4}-\d{2}-\d{2}$/);       // ODATE
-        expect(results[1]).toMatch(/^\d{2}:\d{2}:\d{2}/);        // OTIME
-        expect(results[2]).toMatch(/^\d{4}-\d{2}-\d{2}/);        // OTIMESTAMP
+        expect(results[0]).toMatch(/^\d{4}-\d{2}-\d{2}$/);  // ODATE
+        expect(results[1]).toMatch(/^\d{2}:\d{2}:\d{2}/);   // OTIME
+        expect(results[2]).toMatch(/^\d{4}-\d{2}-\d{2}/);   // OTIMESTAMP
     });
 
 });

--- a/__tests__/__integration__/db2.call.integration.test.ts
+++ b/__tests__/__integration__/db2.call.integration.test.ts
@@ -1,0 +1,117 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import * as fs from "fs";
+import * as path from "path";
+import { runCliScript } from "@zowe/cli-test-utils";
+
+// Integration tests require zowe.config.json at the project root (gitignored).
+// The entire suite is skipped when the file is absent so CI is unaffected.
+const CONFIG_PATH = path.resolve(__dirname, "../../zowe.config.json");
+const SCRIPTS = path.resolve(__dirname, "__scripts__");
+
+const CREATE_TYPESMAP = `
+CREATE PROCEDURE TYPESMAP (
+    IN  ICHAR        CHARACTER(20),
+    IN  IVARCHAR     VARCHAR(20),
+    IN  ISMALLINT    SMALLINT,
+    IN  IINTEGER     INTEGER,
+    IN  IBIGINT      BIGINT,
+    IN  IDECIMAL     DECIMAL(10,2),
+    IN  IREAL        REAL,
+    IN  IDOUBLE      DOUBLE,
+    IN  IDATE        DATE,
+    IN  ITIME        TIME,
+    IN  ITIMESTAMP   TIMESTAMP,
+    OUT OCHAR        CHARACTER(20),
+    OUT OVARCHAR     VARCHAR(20),
+    OUT OSMALLINT    SMALLINT,
+    OUT OINTEGER     INTEGER,
+    OUT OBIGINT      BIGINT,
+    OUT ODECIMAL     DECIMAL(10,2),
+    OUT OREAL        REAL,
+    OUT ODOUBLE      DOUBLE,
+    OUT ODATE        DATE,
+    OUT OTIME        TIME,
+    OUT OTIMESTAMP   TIMESTAMP
+) LANGUAGE SQL
+BEGIN
+    SET OCHAR      = ICHAR;
+    SET OVARCHAR   = IVARCHAR;
+    SET OSMALLINT  = ISMALLINT;
+    SET OINTEGER   = IINTEGER;
+    SET OBIGINT    = IBIGINT;
+    SET ODECIMAL   = IDECIMAL;
+    SET OREAL      = IREAL;
+    SET ODOUBLE    = IDOUBLE;
+    SET ODATE      = IDATE;
+    SET OTIME      = ITIME;
+    SET OTIMESTAMP = ITIMESTAMP;
+END
+`.trim();
+
+const DROP_TYPESMAP = "DROP PROCEDURE TYPESMAP";
+
+const describeOrSkip = fs.existsSync(CONFIG_PATH) ? describe : describe.skip;
+
+describeOrSkip("db2 call stored-proc — integration (live Db2, TYPESMAP)", () => {
+
+    beforeAll(async () => {
+        // Drop any leftover from a previous failed run, then create fresh
+        runCliScript(path.join(SCRIPTS, "execute_inline.sh"), process.cwd() as any, [DROP_TYPESMAP]);
+        const create = runCliScript(path.join(SCRIPTS, "execute_inline.sh"), process.cwd() as any, [CREATE_TYPESMAP]);
+        if (create.status !== 0) {
+            throw new Error(`Failed to create TYPESMAP: ${create.stderr.toString()}`);
+        }
+    });
+
+    afterAll(() => {
+        runCliScript(path.join(SCRIPTS, "execute_inline.sh"), process.cwd() as any, [DROP_TYPESMAP]);
+    });
+
+    it("string OUT params round-trip (CHAR, VARCHAR)", () => {
+        const response = runCliScript(path.join(SCRIPTS, "call_typesmap_strings.sh"), process.cwd() as any);
+        expect(response.status).toBe(0);
+        expect(response.stderr.toString()).toBe("");
+        const data = JSON.parse(response.stdout.toString());
+        expect(data.success).toBe(true);
+        // results array: OUT params come back as individual result entries
+        const results: any[] = data.results;
+        expect(results[0].trim()).toBe("hello");   // OCHAR
+        expect(results[1]).toBe("world");           // OVARCHAR
+    });
+
+    it("numeric OUT params round-trip (SMALLINT, INTEGER, BIGINT, DECIMAL, REAL, DOUBLE)", () => {
+        const response = runCliScript(path.join(SCRIPTS, "call_typesmap_numerics.sh"), process.cwd() as any);
+        expect(response.status).toBe(0);
+        expect(response.stderr.toString()).toBe("");
+        const data = JSON.parse(response.stdout.toString());
+        expect(data.success).toBe(true);
+        const results: any[] = data.results;
+        expect(Number(results[0])).toBe(1);          // OSMALLINT
+        expect(Number(results[1])).toBe(42);         // OINTEGER
+        expect(Number(results[2])).toBe(9999999999); // OBIGINT
+        expect(Number(results[3])).toBeCloseTo(3.14, 1); // ODECIMAL
+    });
+
+    it("date/time OUT params round-trip (DATE, TIME, TIMESTAMP)", () => {
+        const response = runCliScript(path.join(SCRIPTS, "call_typesmap_datetime.sh"), process.cwd() as any);
+        expect(response.status).toBe(0);
+        expect(response.stderr.toString()).toBe("");
+        const data = JSON.parse(response.stdout.toString());
+        expect(data.success).toBe(true);
+        const results: any[] = data.results;
+        expect(results[0]).toMatch(/^\d{4}-\d{2}-\d{2}$/);       // ODATE
+        expect(results[1]).toMatch(/^\d{2}:\d{2}:\d{2}/);        // OTIME
+        expect(results[2]).toMatch(/^\d{4}-\d{2}-\d{2}/);        // OTIMESTAMP
+    });
+
+});

--- a/__tests__/__integration__/db2.execute.integration.test.ts
+++ b/__tests__/__integration__/db2.execute.integration.test.ts
@@ -1,0 +1,91 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import * as fs from "fs";
+import * as path from "path";
+import { runCliScript } from "@zowe/cli-test-utils";
+
+// Integration tests require zowe.config.json at the project root (gitignored).
+// The entire suite is skipped when the file is absent so CI is unaffected.
+const CONFIG_PATH = path.resolve(__dirname, "../../zowe.config.json");
+const SCRIPTS = path.resolve(__dirname, "__scripts__");
+
+const describeOrSkip = fs.existsSync(CONFIG_PATH) ? describe : describe.skip;
+
+describeOrSkip("db2 execute sql — integration (live Db2)", () => {
+
+    it("smoke test: SELECT 1 FROM SYSIBM.SYSDUMMY1", () => {
+        const response = runCliScript(path.join(SCRIPTS, "execute_smoke.sh"), process.cwd() as any);
+        expect(response.status).toBe(0);
+        expect(response.stderr.toString()).toBe("");
+        const data = JSON.parse(response.stdout.toString());
+        expect(Array.isArray(data)).toBe(true);
+        expect(data.length).toBeGreaterThan(0);
+    });
+
+    it("row count: SELECT COUNT(*) FROM SYSIBM.SYSTABLES", () => {
+        const response = runCliScript(path.join(SCRIPTS, "execute_rowcount.sh"), process.cwd() as any);
+        expect(response.status).toBe(0);
+        expect(response.stderr.toString()).toBe("");
+        const data = JSON.parse(response.stdout.toString());
+        expect(data[0]).toBeDefined();
+    });
+
+    it("no rows: SELECT with guaranteed empty result", () => {
+        const response = runCliScript(path.join(SCRIPTS, "execute_norows.sh"), process.cwd() as any);
+        expect(response.status).toBe(0);
+        expect(response.stderr.toString()).toBe("");
+        const data = JSON.parse(response.stdout.toString());
+        expect(Array.isArray(data)).toBe(true);
+        expect(data.length).toBe(0);
+    });
+
+    it("string types: VALUES with CHAR and VARCHAR casts", () => {
+        const response = runCliScript(path.join(SCRIPTS, "execute_strings.sh"), process.cwd() as any);
+        expect(response.status).toBe(0);
+        expect(response.stderr.toString()).toBe("");
+        const data = JSON.parse(response.stdout.toString());
+        expect(data[0]).toBeDefined();
+        const row = data[0];
+        expect(row.C.trim()).toBe("hello");
+        expect(row.V).toBe("world");
+    });
+
+    it("numeric types: VALUES with SMALLINT, INTEGER, BIGINT, DECIMAL, REAL, DOUBLE", () => {
+        const response = runCliScript(path.join(SCRIPTS, "execute_numerics.sh"), process.cwd() as any);
+        expect(response.status).toBe(0);
+        expect(response.stderr.toString()).toBe("");
+        const data = JSON.parse(response.stdout.toString());
+        const row = data[0];
+        expect(Number(row.SI)).toBe(1);
+        expect(Number(row.I)).toBe(42);
+        expect(Number(row.BI)).toBe(9999999999);
+        expect(Number(row.D)).toBeCloseTo(3.14, 1);
+    });
+
+    it("date/time types: VALUES with CURRENT DATE, TIME, TIMESTAMP", () => {
+        const response = runCliScript(path.join(SCRIPTS, "execute_datetime.sh"), process.cwd() as any);
+        expect(response.status).toBe(0);
+        expect(response.stderr.toString()).toBe("");
+        const data = JSON.parse(response.stdout.toString());
+        const row = data[0];
+        expect(row.D).toBeTruthy();
+        expect(row.T).toBeTruthy();
+        expect(row.TS).toBeTruthy();
+    });
+
+    it("error: bad SQL returns non-zero exit", () => {
+        const response = runCliScript(path.join(SCRIPTS, "execute_badsql.sh"), process.cwd() as any);
+        expect(response.status).not.toBe(0);
+        expect(response.stderr.toString()).toMatch(/SQLCODE|error/i);
+    });
+
+});

--- a/__tests__/__integration__/db2.execute.integration.test.ts
+++ b/__tests__/__integration__/db2.execute.integration.test.ts
@@ -41,8 +41,8 @@ describeOrSkip("db2 execute sql — integration (live Db2)", () => {
         expect(response.status).toBe(0);
         expect(response.stderr.toString()).toBe("");
         const data = JSON.parse(response.stdout.toString());
-        expect(Array.isArray(data)).toBe(true);
-        expect(data.length).toBeGreaterThan(0);
+        const rows = Array.isArray(data[0]) ? data[0] : data;
+        expect(rows.length).toBeGreaterThan(0);
     });
 
     it("row count: SELECT COUNT(*) FROM SYSIBM.SYSTABLES", () => {
@@ -50,7 +50,8 @@ describeOrSkip("db2 execute sql — integration (live Db2)", () => {
         expect(response.status).toBe(0);
         expect(response.stderr.toString()).toBe("");
         const data = JSON.parse(response.stdout.toString());
-        expect(data[0]).toBeDefined();
+        const rows = Array.isArray(data[0]) ? data[0] : data;
+        expect(rows[0]).toBeDefined();
     });
 
     it("no rows: SELECT with guaranteed empty result", () => {
@@ -58,8 +59,9 @@ describeOrSkip("db2 execute sql — integration (live Db2)", () => {
         expect(response.status).toBe(0);
         expect(response.stderr.toString()).toBe("");
         const data = JSON.parse(response.stdout.toString());
-        expect(Array.isArray(data)).toBe(true);
-        expect(data.length).toBe(0);
+        // JDBC returns [[]] — outer array is result sets, inner is rows
+        const rows = Array.isArray(data[0]) ? data[0] : data;
+        expect(rows.length).toBe(0);
     });
 
     it("string types: VALUES with CHAR and VARCHAR casts", () => {
@@ -67,8 +69,8 @@ describeOrSkip("db2 execute sql — integration (live Db2)", () => {
         expect(response.status).toBe(0);
         expect(response.stderr.toString()).toBe("");
         const data = JSON.parse(response.stdout.toString());
-        expect(data[0]).toBeDefined();
-        const row = data[0];
+        const row = Array.isArray(data[0]) ? data[0][0] : data[0];
+        expect(row).toBeDefined();
         expect(row.C.trim()).toBe("hello");
         expect(row.V).toBe("world");
     });
@@ -78,7 +80,7 @@ describeOrSkip("db2 execute sql — integration (live Db2)", () => {
         expect(response.status).toBe(0);
         expect(response.stderr.toString()).toBe("");
         const data = JSON.parse(response.stdout.toString());
-        const row = data[0];
+        const row = Array.isArray(data[0]) ? data[0][0] : data[0];
         expect(Number(row.SI)).toBe(1);
         expect(Number(row.I)).toBe(42);
         expect(Number(row.BI)).toBe(9999999999);
@@ -90,7 +92,7 @@ describeOrSkip("db2 execute sql — integration (live Db2)", () => {
         expect(response.status).toBe(0);
         expect(response.stderr.toString()).toBe("");
         const data = JSON.parse(response.stdout.toString());
-        const row = data[0];
+        const row = Array.isArray(data[0]) ? data[0][0] : data[0];
         expect(row.D).toBeTruthy();
         expect(row.T).toBeTruthy();
         expect(row.TS).toBeTruthy();

--- a/__tests__/__integration__/db2.execute.integration.test.ts
+++ b/__tests__/__integration__/db2.execute.integration.test.ts
@@ -11,19 +11,33 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import { runCliScript } from "@zowe/cli-test-utils";
+import { ITestEnvironment, TestEnvironment, runCliScript } from "@zowe/cli-test-utils";
+import { IIntegrationTestProperties } from "./doc/IIntegrationTestProperties";
 
-// Integration tests require zowe.config.json at the project root (gitignored).
-// The entire suite is skipped when the file is absent so CI is unaffected.
-const CONFIG_PATH = path.resolve(__dirname, "../../zowe.config.json");
+// Skip the entire suite if custom_properties.yaml is absent (no live Db2 configured)
+const PROPS_PATH = path.resolve(__dirname, "../__resources__/properties/custom_properties.yaml");
+const describeOrSkip = fs.existsSync(PROPS_PATH) ? describe : describe.skip;
+
 const SCRIPTS = path.resolve(__dirname, "__scripts__");
 
-const describeOrSkip = fs.existsSync(CONFIG_PATH) ? describe : describe.skip;
+let TEST_ENV: ITestEnvironment<IIntegrationTestProperties>;
 
 describeOrSkip("db2 execute sql — integration (live Db2)", () => {
 
+    beforeAll(async () => {
+        TEST_ENV = await TestEnvironment.setUp({
+            installPlugin: true,
+            tempProfileTypes: ["db2"],
+            testName: "integration_execute",
+        });
+    });
+
+    afterAll(async () => {
+        await TestEnvironment.cleanUp(TEST_ENV);
+    });
+
     it("smoke test: SELECT 1 FROM SYSIBM.SYSDUMMY1", () => {
-        const response = runCliScript(path.join(SCRIPTS, "execute_smoke.sh"), process.cwd() as any);
+        const response = runCliScript(path.join(SCRIPTS, "execute_smoke.sh"), TEST_ENV);
         expect(response.status).toBe(0);
         expect(response.stderr.toString()).toBe("");
         const data = JSON.parse(response.stdout.toString());
@@ -32,7 +46,7 @@ describeOrSkip("db2 execute sql — integration (live Db2)", () => {
     });
 
     it("row count: SELECT COUNT(*) FROM SYSIBM.SYSTABLES", () => {
-        const response = runCliScript(path.join(SCRIPTS, "execute_rowcount.sh"), process.cwd() as any);
+        const response = runCliScript(path.join(SCRIPTS, "execute_rowcount.sh"), TEST_ENV);
         expect(response.status).toBe(0);
         expect(response.stderr.toString()).toBe("");
         const data = JSON.parse(response.stdout.toString());
@@ -40,7 +54,7 @@ describeOrSkip("db2 execute sql — integration (live Db2)", () => {
     });
 
     it("no rows: SELECT with guaranteed empty result", () => {
-        const response = runCliScript(path.join(SCRIPTS, "execute_norows.sh"), process.cwd() as any);
+        const response = runCliScript(path.join(SCRIPTS, "execute_norows.sh"), TEST_ENV);
         expect(response.status).toBe(0);
         expect(response.stderr.toString()).toBe("");
         const data = JSON.parse(response.stdout.toString());
@@ -49,7 +63,7 @@ describeOrSkip("db2 execute sql — integration (live Db2)", () => {
     });
 
     it("string types: VALUES with CHAR and VARCHAR casts", () => {
-        const response = runCliScript(path.join(SCRIPTS, "execute_strings.sh"), process.cwd() as any);
+        const response = runCliScript(path.join(SCRIPTS, "execute_strings.sh"), TEST_ENV);
         expect(response.status).toBe(0);
         expect(response.stderr.toString()).toBe("");
         const data = JSON.parse(response.stdout.toString());
@@ -60,7 +74,7 @@ describeOrSkip("db2 execute sql — integration (live Db2)", () => {
     });
 
     it("numeric types: VALUES with SMALLINT, INTEGER, BIGINT, DECIMAL, REAL, DOUBLE", () => {
-        const response = runCliScript(path.join(SCRIPTS, "execute_numerics.sh"), process.cwd() as any);
+        const response = runCliScript(path.join(SCRIPTS, "execute_numerics.sh"), TEST_ENV);
         expect(response.status).toBe(0);
         expect(response.stderr.toString()).toBe("");
         const data = JSON.parse(response.stdout.toString());
@@ -72,7 +86,7 @@ describeOrSkip("db2 execute sql — integration (live Db2)", () => {
     });
 
     it("date/time types: VALUES with CURRENT DATE, TIME, TIMESTAMP", () => {
-        const response = runCliScript(path.join(SCRIPTS, "execute_datetime.sh"), process.cwd() as any);
+        const response = runCliScript(path.join(SCRIPTS, "execute_datetime.sh"), TEST_ENV);
         expect(response.status).toBe(0);
         expect(response.stderr.toString()).toBe("");
         const data = JSON.parse(response.stdout.toString());
@@ -83,7 +97,7 @@ describeOrSkip("db2 execute sql — integration (live Db2)", () => {
     });
 
     it("error: bad SQL returns non-zero exit", () => {
-        const response = runCliScript(path.join(SCRIPTS, "execute_badsql.sh"), process.cwd() as any);
+        const response = runCliScript(path.join(SCRIPTS, "execute_badsql.sh"), TEST_ENV);
         expect(response.status).not.toBe(0);
         expect(response.stderr.toString()).toMatch(/SQLCODE|error/i);
     });

--- a/__tests__/__integration__/doc/IIntegrationTestProperties.ts
+++ b/__tests__/__integration__/doc/IIntegrationTestProperties.ts
@@ -1,0 +1,31 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+/**
+ * Properties read from custom_properties.yaml for integration tests.
+ * Kept separate from ITestPropertiesSchema to avoid touching the existing
+ * system test infrastructure.
+ */
+export interface IIntegrationTestProperties {
+    db2: {
+        host: string;
+        port: number;
+        user: string;
+        password: string;
+        database: string;
+        sslFile?: string;
+        driverType?: string;
+        jdbcJarPath?: string;
+        jdbcLicensePath?: string;
+        javaPath?: string;
+        jdbcProperties?: string;
+    };
+}

--- a/__tests__/__resources__/properties/example_properties.yaml
+++ b/__tests__/__resources__/properties/example_properties.yaml
@@ -1,15 +1,21 @@
 ###############################################################################
-# Example properties file for the CA Brightside Db2 plug-in                   #
+# Example properties file for the Zowe CLI Db2 plug-in                       #
 # Copy this to custom_properties.yaml in the same directory                   #
-# and modify to fill in your customized connection and test details           #
-#-----------------------------------------------------------------------------#
-#  Find and replace the following:                                            #
-#                                                                             #
-#  my-user-name     - This is your TSO user ID                                #
-#  my-password      - This is your TSO password                               #
-#  my-db2-host      - This is the hostname for the DB2 for z/OS server        #
-#  my-db2-port      - This is the port for the DB2 for z/OS server            #
-#  my-database-name - This is the name of the database                        #
+# and modify to fill in your connection details.                               #
+#                                                                              #
+# These properties are used by both system tests (__tests__/__system__/)      #
+# and integration tests (__tests__/__integration__/).                          #
+#                                                                              #
+# Required for all tests:                                                      #
+#   my-db2-host      - hostname for the Db2 for z/OS server                   #
+#   my-db2-port      - port for the Db2 for z/OS server                       #
+#   my-database-name - Db2 database/subsystem name                            #
+#   my-user-name     - TSO user ID                                             #
+#   my-password      - TSO password                                            #
+#                                                                              #
+# Required for JDBC integration tests (driverType: jdbc):                     #
+#   /path/to/db2jcc4.jar           - Db2 JDBC driver JAR                      #
+#   /path/to/db2jcc_license_cisuz.jar - Db2 JDBC license JAR                  #
 ###############################################################################
 
 db2:
@@ -18,3 +24,16 @@ db2:
     database: my-database-name
     user:     my-user-name
     password: my-password
+
+    # --- JDBC driver settings (required for integration tests) ---
+    # Remove or set to "odbc" to use the ODBC driver instead (requires IBM Data Server Driver)
+    driverType: jdbc
+    jdbcJarPath: /path/to/db2jcc4.jar
+    jdbcLicensePath: /path/to/db2jcc_license_cisuz.jar
+    # Path to java executable — defaults to "java" if omitted
+    javaPath: java
+    # Optional additional JDBC connection properties
+    # jdbcProperties: "securityMechanism=13;clientProgramName=ZoweCLI;"
+
+    # --- SSL (optional) ---
+    # sslFile: /path/to/server.crt

--- a/__tests__/__snapshots__/imperative.test.ts.snap
+++ b/__tests__/__snapshots__/imperative.test.ts.snap
@@ -24,6 +24,17 @@ Object {
             },
             "type": "string",
           },
+          "driverType": Object {
+            "optionDefinition": Object {
+              "aliases": Array [
+                "driver",
+              ],
+              "description": "Driver type used to connect to Db2: 'odbc' or 'jdbc'",
+              "name": "driver-type",
+              "type": "string",
+            },
+            "type": "string",
+          },
           "host": Object {
             "optionDefinition": Object {
               "aliases": Array [
@@ -31,6 +42,41 @@ Object {
               ],
               "description": "The Db2 server host name",
               "name": "host",
+              "type": "string",
+            },
+            "type": "string",
+          },
+          "javaPath": Object {
+            "optionDefinition": Object {
+              "description": "Path to Java executable to use for JDBC connections",
+              "name": "java-path",
+              "type": "string",
+            },
+            "type": "string",
+          },
+          "jdbcJarPath": Object {
+            "optionDefinition": Object {
+              "description": "Path to the Db2 JDBC driver JAR file (e.g. db2jcc4.jar) or directory containing it",
+              "name": "jdbc-jar",
+              "type": "string",
+            },
+            "type": "string",
+          },
+          "jdbcLicensePath": Object {
+            "optionDefinition": Object {
+              "description": "Path to the Db2 JDBC license JAR file (e.g. db2jcc_license_cisuz.jar) or directory containing it",
+              "name": "jdbc-license",
+              "type": "string",
+            },
+            "type": "string",
+          },
+          "jdbcProperties": Object {
+            "optionDefinition": Object {
+              "aliases": Array [
+                "jdbc-properties",
+              ],
+              "description": "Additional JDBC connection properties",
+              "name": "jdbc-props",
               "type": "string",
             },
             "type": "string",

--- a/__tests__/__src__/environment/doc/ITestPropertiesSchema.ts
+++ b/__tests__/__src__/environment/doc/ITestPropertiesSchema.ts
@@ -48,5 +48,30 @@ export interface ITestPropertiesSchema {
          * Path to an SSL Certificate file
          */
         sslFile?: string,
+
+        /**
+         * Driver type: "odbc" or "jdbc"
+         */
+        driverType?: string,
+
+        /**
+         * Path to the Db2 JDBC driver JAR (e.g. db2jcc4.jar)
+         */
+        jdbcJarPath?: string,
+
+        /**
+         * Path to the Db2 JDBC license JAR (e.g. db2jcc_license_cisuz.jar)
+         */
+        jdbcLicensePath?: string,
+
+        /**
+         * Path to java executable (defaults to "java")
+         */
+        javaPath?: string,
+
+        /**
+         * Additional JDBC connection properties string
+         */
+        jdbcProperties?: string,
     };
 }

--- a/__tests__/api/ConnectionString.test.ts
+++ b/__tests__/api/ConnectionString.test.ts
@@ -71,4 +71,16 @@ describe("ConnectionString", () => {
             expect(connectionString).toMatchSnapshot();
         });
     });
+
+    describe("buildJdbcUrl", () => {
+        it("should build correct JDBC connection URL from session", () => {
+            const jdbcUrl = ConnectionString.buildJdbcUrlFromSession(SIMPLE_SESSION);
+            expect(jdbcUrl).toBe(`jdbc:db2://${C.HOST_NAME}:${C.PORT}/${C.DATABASE_NAME}`);
+        });
+
+        it("should build correct JDBC connection URL with SSL file", () => {
+            const jdbcUrl = ConnectionString.buildJdbcUrlFromSession(SECURE_SESSION);
+            expect(jdbcUrl).toBe(`jdbc:db2://${C.HOST_NAME}:${C.PORT}/${C.DATABASE_NAME}:sslConnection=true;sslTrustStoreLocation=${C.SSL_FILE};`);
+        });
+    });
 });

--- a/__tests__/api/ConnectionString.test.ts
+++ b/__tests__/api/ConnectionString.test.ts
@@ -79,8 +79,21 @@ describe("ConnectionString", () => {
         });
 
         it("should build correct JDBC connection URL with SSL file", () => {
-            const jdbcUrl = ConnectionString.buildJdbcUrlFromSession(SECURE_SESSION);
-            expect(jdbcUrl).toBe(`jdbc:db2://${C.HOST_NAME}:${C.PORT}/${C.DATABASE_NAME}:sslConnection=true;sslTrustStoreLocation=${C.SSL_FILE};`);
+            // Use a real file that exists on every system for the path validation check
+            const sslFile = __filename; // the test file itself always exists
+            const session = { ...SIMPLE_SESSION, sslFile };
+            const jdbcUrl = ConnectionString.buildJdbcUrlFromSession(session);
+            expect(jdbcUrl).toBe(`jdbc:db2://${C.HOST_NAME}:${C.PORT}/${C.DATABASE_NAME}:sslConnection=true;sslTrustStoreLocation=${sslFile};`);
+        });
+
+        it("should throw when sslFile does not exist", () => {
+            const session = { ...SIMPLE_SESSION, sslFile: "/no/such/file.crt" };
+            expect(() => ConnectionString.buildJdbcUrlFromSession(session)).toThrow("sslFile must be an absolute path");
+        });
+
+        it("should throw when jdbcProperties contains a blocked key", () => {
+            expect(() => ConnectionString.buildJdbcUrl(C.HOST_NAME, C.PORT, C.DATABASE_NAME, undefined, "user=hacker"))
+                .toThrow("must not override security-sensitive key");
         });
     });
 });

--- a/__tests__/api/DriverFactory.test.ts
+++ b/__tests__/api/DriverFactory.test.ts
@@ -1,0 +1,106 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { DB2DriverFactory, OdbcDriver, JdbcDriver, IDB2Session } from "../../src";
+import * as child_process from "child_process";
+import * as C from "../Db2TestConstants";
+
+jest.mock("child_process");
+
+const ODBC_SESSION: IDB2Session = {
+    hostname: C.HOST_NAME,
+    port: C.PORT,
+    user: C.USER_NAME,
+    password: C.PASSWORD,
+    database: C.DATABASE_NAME,
+    driverType: "odbc",
+};
+
+const JDBC_SESSION: IDB2Session = {
+    hostname: C.HOST_NAME,
+    port: C.PORT,
+    user: C.USER_NAME,
+    password: C.PASSWORD,
+    database: C.DATABASE_NAME,
+    driverType: "jdbc",
+    jdbcJarPath: "/path/to/db2jcc4.jar",
+    jdbcLicensePath: "/path/to/db2jcc_license_cisuz.jar",
+    javaPath: "/usr/bin/java",
+};
+
+describe("DB2DriverFactory", () => {
+    it("should instantiate OdbcDriver when driverType is odbc or undefined", () => {
+        const defaultDriver = DB2DriverFactory.getDriver({
+            hostname: C.HOST_NAME,
+            port: C.PORT,
+            user: C.USER_NAME,
+            password: C.PASSWORD,
+            database: C.DATABASE_NAME,
+        });
+        expect(defaultDriver).toBeInstanceOf(OdbcDriver);
+
+        const odbcDriver = DB2DriverFactory.getDriver(ODBC_SESSION);
+        expect(odbcDriver).toBeInstanceOf(OdbcDriver);
+    });
+
+    it("should instantiate JdbcDriver when driverType is jdbc", () => {
+        const jdbcDriver = DB2DriverFactory.getDriver(JDBC_SESSION);
+        expect(jdbcDriver).toBeInstanceOf(JdbcDriver);
+    });
+});
+
+describe("JdbcDriver", () => {
+    it("should build correct classpath", () => {
+        const driver = new JdbcDriver(JDBC_SESSION);
+        const cp = driver.buildClasspath();
+        expect(cp).toContain("/path/to/db2jcc4.jar");
+        expect(cp).toContain("/path/to/db2jcc_license_cisuz.jar");
+    });
+
+    it("should execute SQL via Java subprocess", () => {
+        const mockExec = jest.spyOn(child_process, "execFileSync").mockReturnValue(
+            JSON.stringify([[{ COL1: "VAL1" }]])
+        );
+
+        const driver = new JdbcDriver(JDBC_SESSION);
+        const results = Array.from(driver.execute("SELECT * FROM MYTABLE"));
+
+        expect(mockExec).toHaveBeenCalled();
+        expect(results).toEqual([[{ COL1: "VAL1" }]]);
+        mockExec.mockRestore();
+    });
+
+    it("should call stored procedure via Java subprocess", () => {
+        const mockExec = jest.spyOn(child_process, "execFileSync").mockReturnValue(
+            JSON.stringify({ success: true, results: ["OUT_VAL"] })
+        );
+
+        const driver = new JdbcDriver(JDBC_SESSION);
+        const resp = driver.callSP("MY_PROC", []);
+
+        expect(resp.success).toBe(true);
+        expect(resp.results).toEqual(["OUT_VAL"]);
+        mockExec.mockRestore();
+    });
+
+    it("should get table columns via Java subprocess", async () => {
+        const mockCols = [{ COLUMN_NAME: "COL1", DATA_TYPE: 4, TYPE_NAME: "INTEGER" }];
+        const mockExec = jest.spyOn(child_process, "execFileSync").mockReturnValue(
+            JSON.stringify(mockCols)
+        );
+
+        const driver = new JdbcDriver(JDBC_SESSION);
+        const cols = await driver.getTableColumns("MYDB", "MYTABLE");
+
+        expect(cols).toEqual(mockCols);
+        mockExec.mockRestore();
+    });
+});

--- a/__tests__/api/SessionValidator.test.ts
+++ b/__tests__/api/SessionValidator.test.ts
@@ -160,7 +160,12 @@ describe("SessionValidator", () => {
 
         it("should accept valid driverType 'odbc' or 'jdbc'", () => {
             expect(() => SessionValidator.validate({ ...SESSION_GOOD, driverType: "odbc" })).not.toThrow();
-            expect(() => SessionValidator.validate({ ...SESSION_GOOD, driverType: "jdbc" })).not.toThrow();
+            expect(() => SessionValidator.validate({ ...SESSION_GOOD, driverType: "jdbc", jdbcJarPath: "/path/to/db2jcc4.jar" })).not.toThrow();
+        });
+
+        it("should throw when driverType is jdbc and jdbcJarPath is missing", () => {
+            expect(() => SessionValidator.validate({ ...SESSION_GOOD, driverType: "jdbc" }))
+                .toThrow("jdbcJarPath is required");
         });
 
         it("should throw error for invalid driverType", () => {

--- a/__tests__/api/SessionValidator.test.ts
+++ b/__tests__/api/SessionValidator.test.ts
@@ -157,5 +157,14 @@ describe("SessionValidator", () => {
             expect(error).toBeDefined();
             expect(error.toString()).toMatchSnapshot();
         });
+
+        it("should accept valid driverType 'odbc' or 'jdbc'", () => {
+            expect(() => SessionValidator.validate({ ...SESSION_GOOD, driverType: "odbc" })).not.toThrow();
+            expect(() => SessionValidator.validate({ ...SESSION_GOOD, driverType: "jdbc" })).not.toThrow();
+        });
+
+        it("should throw error for invalid driverType", () => {
+            expect(() => SessionValidator.validate({ ...SESSION_GOOD, driverType: "invalid" as any })).toThrow("Invalid driverType");
+        });
     });
 });

--- a/__tests__/cli/call/__snapshots__/Call.definition.unit.test.ts.snap
+++ b/__tests__/cli/call/__snapshots__/Call.definition.unit.test.ts.snap
@@ -69,6 +69,59 @@ Object {
           "name": "sslFile",
           "type": "string",
         },
+        Object {
+          "aliases": Array [
+            "driver",
+          ],
+          "allowableValues": Object {
+            "caseSensitive": false,
+            "values": Array [
+              "odbc",
+              "jdbc",
+            ],
+          },
+          "defaultValue": "odbc",
+          "description": "Driver type used to connect to Db2: 'odbc' or 'jdbc'",
+          "group": "DB2 Connection Options",
+          "name": "driverType",
+          "type": "string",
+        },
+        Object {
+          "aliases": Array [
+            "jdbc-jar",
+          ],
+          "description": "Path to the Db2 JDBC driver JAR file (e.g. db2jcc4.jar) or directory containing it",
+          "group": "DB2 Connection Options",
+          "name": "jdbcJarPath",
+          "type": "string",
+        },
+        Object {
+          "aliases": Array [
+            "jdbc-license",
+          ],
+          "description": "Path to the Db2 JDBC license JAR file (e.g. db2jcc_license_cisuz.jar) or directory containing it",
+          "group": "DB2 Connection Options",
+          "name": "jdbcLicensePath",
+          "type": "string",
+        },
+        Object {
+          "aliases": Array [
+            "java-path",
+          ],
+          "description": "Path to Java executable to use for JDBC connections (defaults to 'java')",
+          "group": "DB2 Connection Options",
+          "name": "javaPath",
+          "type": "string",
+        },
+        Object {
+          "aliases": Array [
+            "jdbc-props",
+          ],
+          "description": "Additional JDBC connection properties (e.g. 'securityMechanism=13;clientProgramName=ZoweCLI;')",
+          "group": "DB2 Connection Options",
+          "name": "jdbcProperties",
+          "type": "string",
+        },
       ],
     },
   ],

--- a/__tests__/cli/call/__snapshots__/Call.definition.unit.test.ts.snap
+++ b/__tests__/cli/call/__snapshots__/Call.definition.unit.test.ts.snap
@@ -117,7 +117,7 @@ Object {
           "aliases": Array [
             "jdbc-props",
           ],
-          "description": "Additional JDBC connection properties (e.g. 'securityMechanism=13;clientProgramName=ZoweCLI;')",
+          "description": "Additional JDBC connection properties (e.g. 'clientProgramName=ZoweCLI;'). Security-sensitive keys (user, password, sslConnection, securityMechanism) are not permitted.",
           "group": "DB2 Connection Options",
           "name": "jdbcProperties",
           "type": "string",

--- a/__tests__/cli/execute/__snapshots__/Execute.definition.unit.test.ts.snap
+++ b/__tests__/cli/execute/__snapshots__/Execute.definition.unit.test.ts.snap
@@ -69,6 +69,59 @@ Object {
           "name": "sslFile",
           "type": "string",
         },
+        Object {
+          "aliases": Array [
+            "driver",
+          ],
+          "allowableValues": Object {
+            "caseSensitive": false,
+            "values": Array [
+              "odbc",
+              "jdbc",
+            ],
+          },
+          "defaultValue": "odbc",
+          "description": "Driver type used to connect to Db2: 'odbc' or 'jdbc'",
+          "group": "DB2 Connection Options",
+          "name": "driverType",
+          "type": "string",
+        },
+        Object {
+          "aliases": Array [
+            "jdbc-jar",
+          ],
+          "description": "Path to the Db2 JDBC driver JAR file (e.g. db2jcc4.jar) or directory containing it",
+          "group": "DB2 Connection Options",
+          "name": "jdbcJarPath",
+          "type": "string",
+        },
+        Object {
+          "aliases": Array [
+            "jdbc-license",
+          ],
+          "description": "Path to the Db2 JDBC license JAR file (e.g. db2jcc_license_cisuz.jar) or directory containing it",
+          "group": "DB2 Connection Options",
+          "name": "jdbcLicensePath",
+          "type": "string",
+        },
+        Object {
+          "aliases": Array [
+            "java-path",
+          ],
+          "description": "Path to Java executable to use for JDBC connections (defaults to 'java')",
+          "group": "DB2 Connection Options",
+          "name": "javaPath",
+          "type": "string",
+        },
+        Object {
+          "aliases": Array [
+            "jdbc-props",
+          ],
+          "description": "Additional JDBC connection properties (e.g. 'securityMechanism=13;clientProgramName=ZoweCLI;')",
+          "group": "DB2 Connection Options",
+          "name": "jdbcProperties",
+          "type": "string",
+        },
       ],
     },
   ],

--- a/__tests__/cli/execute/__snapshots__/Execute.definition.unit.test.ts.snap
+++ b/__tests__/cli/execute/__snapshots__/Execute.definition.unit.test.ts.snap
@@ -117,7 +117,7 @@ Object {
           "aliases": Array [
             "jdbc-props",
           ],
-          "description": "Additional JDBC connection properties (e.g. 'securityMechanism=13;clientProgramName=ZoweCLI;')",
+          "description": "Additional JDBC connection properties (e.g. 'clientProgramName=ZoweCLI;'). Security-sensitive keys (user, password, sslConnection, securityMechanism) are not permitted.",
           "group": "DB2 Connection Options",
           "name": "jdbcProperties",
           "type": "string",

--- a/__tests__/cli/export/__snapshots__/Export.definition.unit.test.ts.snap
+++ b/__tests__/cli/export/__snapshots__/Export.definition.unit.test.ts.snap
@@ -69,6 +69,59 @@ Object {
           "name": "sslFile",
           "type": "string",
         },
+        Object {
+          "aliases": Array [
+            "driver",
+          ],
+          "allowableValues": Object {
+            "caseSensitive": false,
+            "values": Array [
+              "odbc",
+              "jdbc",
+            ],
+          },
+          "defaultValue": "odbc",
+          "description": "Driver type used to connect to Db2: 'odbc' or 'jdbc'",
+          "group": "DB2 Connection Options",
+          "name": "driverType",
+          "type": "string",
+        },
+        Object {
+          "aliases": Array [
+            "jdbc-jar",
+          ],
+          "description": "Path to the Db2 JDBC driver JAR file (e.g. db2jcc4.jar) or directory containing it",
+          "group": "DB2 Connection Options",
+          "name": "jdbcJarPath",
+          "type": "string",
+        },
+        Object {
+          "aliases": Array [
+            "jdbc-license",
+          ],
+          "description": "Path to the Db2 JDBC license JAR file (e.g. db2jcc_license_cisuz.jar) or directory containing it",
+          "group": "DB2 Connection Options",
+          "name": "jdbcLicensePath",
+          "type": "string",
+        },
+        Object {
+          "aliases": Array [
+            "java-path",
+          ],
+          "description": "Path to Java executable to use for JDBC connections (defaults to 'java')",
+          "group": "DB2 Connection Options",
+          "name": "javaPath",
+          "type": "string",
+        },
+        Object {
+          "aliases": Array [
+            "jdbc-props",
+          ],
+          "description": "Additional JDBC connection properties (e.g. 'securityMechanism=13;clientProgramName=ZoweCLI;')",
+          "group": "DB2 Connection Options",
+          "name": "jdbcProperties",
+          "type": "string",
+        },
       ],
     },
   ],

--- a/__tests__/cli/export/__snapshots__/Export.definition.unit.test.ts.snap
+++ b/__tests__/cli/export/__snapshots__/Export.definition.unit.test.ts.snap
@@ -117,7 +117,7 @@ Object {
           "aliases": Array [
             "jdbc-props",
           ],
-          "description": "Additional JDBC connection properties (e.g. 'securityMechanism=13;clientProgramName=ZoweCLI;')",
+          "description": "Additional JDBC connection properties (e.g. 'clientProgramName=ZoweCLI;'). Security-sensitive keys (user, password, sslConnection, securityMechanism) are not permitted.",
           "group": "DB2 Connection Options",
           "name": "jdbcProperties",
           "type": "string",

--- a/docs/jdbc_hardening.md
+++ b/docs/jdbc_hardening.md
@@ -104,11 +104,15 @@ The Java single-file source launcher emitted an unchecked cast warning to stderr
 
 ## Nice-to-Have (can follow in a subsequent PR)
 
-### H6 — No system tests for JDBC pathway
+### H6 — Integration tests for JDBC pathway (partially addressed)
 
-All system tests in [`__tests__/__system__`](../__tests__/__system__) are ODBC-only. End-to-end correctness of `execute sql`, `export table`, and `call procedure` via JDBC against a real Db2 instance has not been formally verified by CI.
+Live JDBC integration tests now exist under [`__tests__/__integration__/`](../__tests__/__integration__/) and run via `npm run test:integration`. They are skipped automatically when `__tests__/__resources__/properties/custom_properties.yaml` is absent, so CI is unaffected.
 
-**Proposal:** Add `DRIVER_TYPE=jdbc` variants for `execute sql` and `call` in the system test suite, gated by a `JDBC_JAR_PATH` env var so they are skipped when no JAR is present.
+**Status:**
+- ✅ `db2.execute.integration.test.ts` — 7 tests passing against live Db2 z/OS (smoke, row count, no-rows, strings, numerics, date/time, error)
+- ❌ `db2.call.integration.test.ts` — `CREATE PROCEDURE` for `TYPESMAP` fails with `SQLCODE=-20071` (WLM environment required on this subsystem); tests are written but blocked pending either DBA pre-creation of the proc or a subsystem with `CREATE PROCEDURE` permission
+
+**Note:** ODBC path cannot be live-tested without the IBM Data Server Driver license. All integration tests use JDBC via the profile's `driverType: jdbc`.
 
 ---
 
@@ -147,4 +151,5 @@ Before squashing and opening the PR against `master`:
 - [ ] `npm run build` passes (TypeScript + `javac` or graceful fallback)
 - [ ] `npm run test:unit` passes with no new failures
 - [ ] `npm run lint` clean
+- [ ] `npm run test:integration` passes (requires `custom_properties.yaml` with JDBC config)
 - [ ] This file is **deleted** from the branch

--- a/docs/jdbc_hardening.md
+++ b/docs/jdbc_hardening.md
@@ -1,0 +1,150 @@
+# JDBC Hardening Checklist — Pre-Release
+
+> **Ephemeral document.** Delete this file before merging the PR. Items should be tracked as issues or inline TODOs once resolved.
+
+Branch: `jdbc-support`  
+Target: merge to `master` as v6.1.17
+
+---
+
+## Must-Fix (blockers)
+
+### H1 — OUT parameter SQL type is hardcoded to `VARCHAR`
+
+**File:** [`src/java/Db2JdbcRunner.java:184`](../src/java/Db2JdbcRunner.java)
+
+`registerOutParameter` always registers `Types.VARCHAR`. Numeric, date, timestamp, and BLOB output parameters will be silently miscast or fail at runtime.
+
+**Fix:** Add a `sqlType` field to the parameter JSON object (e.g. `{ "ParamType": 2, "Data": null, "SqlType": 4 }`). Extend `IDB2Parameter`, update `JdbcDriver.callSP()` serialisation, and use the passed-in type code in `registerOutParameter`.
+
+- [ ] `IDB2Parameter` — add optional `SqlType?: number`
+- [ ] `JdbcDriver.callSP()` — include `SqlType` in JSON when set
+- [ ] `Db2JdbcRunner.java` — use `sqlType` in `registerOutParameter`, default to `Types.VARCHAR` only when absent
+- [ ] Unit test covering OUT with a non-VARCHAR type
+
+---
+
+### H2 — No SQLCODE/SQLSTATE surfaced from JDBC `SQLException`
+
+**File:** [`src/api/DB2Error.ts`](../src/api/DB2Error.ts), [`src/java/Db2JdbcRunner.java`](../src/java/Db2JdbcRunner.java)
+
+JDBC failures arrive as plain `Error` objects thrown from `runJavaCommand()`. `DB2Error.process()` cannot extract SQLCODE or SQLSTATE, so the user sees a raw Java stack trace instead of a structured error message.
+
+**Fix:** Have `Db2JdbcRunner` write a structured JSON error to stderr on failure (e.g. `{"error":true,"sqlcode":-204,"sqlstate":"42704","message":"..."}`) and have `runJavaCommand()` parse and rethrow it as a typed object that `DB2Error.process()` can handle.
+
+- [ ] `Db2JdbcRunner.java` — catch `SQLException`, emit JSON to stderr
+- [ ] `JdbcDriver.runJavaCommand()` — parse stderr JSON and rethrow as structured object
+- [ ] `DB2Error.process()` — handle JDBC error shape (extract `sqlcode`, `sqlstate`)
+- [ ] Unit test: mock `execFileSync` to throw with JSON stderr, assert `ImperativeError` contains SQLCODE
+
+---
+
+## Should-Fix (high confidence regressions or test coverage gaps)
+
+### H3 — `getTableRows` has no unit test
+
+**File:** [`src/api/driver/JdbcDriver.ts:176`](../src/api/driver/JdbcDriver.ts), [`__tests__/api/DriverFactory.test.ts`](../__tests__/api/DriverFactory.test.ts)
+
+`JdbcDriver.getTableRows()` is the method called by `ExportTable` — one of the three primary commands. It is implemented but completely untested.
+
+**Fix:** Mock `execFileSync` returning `[[{"COL":"VAL1"},{"COL":"VAL2"}]]` and assert rows are yielded in order.
+
+- [ ] Add `getTableRows` test in `DriverFactory.test.ts`
+
+---
+
+### H4 — `callSP` OUT/INOUT parameter paths are untested
+
+**File:** [`__tests__/api/DriverFactory.test.ts:81`](../__tests__/api/DriverFactory.test.ts)
+
+The existing `callSP` test passes an empty parameter array. The OUT and INOUT serialisation paths in both `JdbcDriver.callSP()` and `Db2JdbcRunner.callProcedure()` are never exercised by unit tests.
+
+**Fix:** Add tests passing `IDB2Parameter` objects with `ParamType` 2 (OUTPUT) and 3 (INOUT), asserting the correct JSON shape is written to stdin and the response is unpacked.
+
+- [ ] Add `callSP` with OUTPUT param test
+- [ ] Add `callSP` with INOUT param test
+
+---
+
+### H5 — `driverType` backwards compat: `imperative.ts` profile schema has no `defaultValue` or `allowableValues`
+
+**File:** [`src/imperative.ts:86`](../src/imperative.ts), [`src/cli/DB2Session.ts:93`](../src/cli/DB2Session.ts)
+
+`DB2Session.ts` correctly declares `defaultValue: "odbc"` and `allowableValues: ["odbc","jdbc"]` on `DB2_OPTION_DRIVER_TYPE`. The corresponding `optionDefinition` in `imperative.ts` (used for v1 profile management) omits both, so a user running `zowe profiles create db2` would not see the valid values or get the default.
+
+**Fix:** Add `defaultValue: "odbc"` and `allowableValues` to the `driverType` `optionDefinition` in `imperative.ts`.
+
+- [ ] `imperative.ts` — add `defaultValue: "odbc"` and `allowableValues: { values: ["odbc","jdbc"], caseSensitive: false }` to `driverType.optionDefinition`
+
+---
+
+## Discovered During Testing
+
+### H11 — Binary columns render as Java object references (`[B@...`)
+
+**File:** [`src/java/Db2JdbcRunner.java`](../src/java/Db2JdbcRunner.java)
+
+`resultSetToListOfMaps` calls `rs.getObject(i)` for all column types. For binary/ROWID columns (`ROWID`, `CHAR FOR BIT DATA`, `VARCHAR FOR BIT DATA`) this returns a `byte[]`, and the JSON serialiser calls `.toString()` on it, producing garbage like `[B@a767d18` instead of a hex or base64 string.
+
+**Fix:** In `resultSetToListOfMaps`, detect `byte[]` values and encode them as hex strings.
+
+- [ ] `Db2JdbcRunner.java` — check `val instanceof byte[]` and emit hex string
+
+---
+
+### H12 — Compiler warning on stderr corrupts error messages (fixed)
+
+**File:** [`src/api/driver/JdbcDriver.ts`](../src/api/driver/JdbcDriver.ts), [`src/java/Db2JdbcRunner.java`](../src/java/Db2JdbcRunner.java)
+
+The Java single-file source launcher emitted an unchecked cast warning to stderr on every invocation. On success this was interleaved with output; on failure it prepended the warning to the actual error message, making it unreadable.
+
+**Fixed:** Added `@SuppressWarnings("unchecked")` to `parseJsonArray` in the Java source, and added `-Xlint:none` to the source launcher args. Also hardened the error path in `runJavaCommand` to strip compiler warning lines from stderr before surfacing the error.
+
+---
+
+## Nice-to-Have (can follow in a subsequent PR)
+
+### H6 — No system tests for JDBC pathway
+
+All system tests in [`__tests__/__system__`](../__tests__/__system__) are ODBC-only. End-to-end correctness of `execute sql`, `export table`, and `call procedure` via JDBC against a real Db2 instance has not been formally verified by CI.
+
+**Proposal:** Add `DRIVER_TYPE=jdbc` variants for `execute sql` and `call` in the system test suite, gated by a `JDBC_JAR_PATH` env var so they are skipped when no JAR is present.
+
+---
+
+### H7 — `jdbcProperties` semicolons in values are not handled
+
+**File:** [`src/api/ConnectionString.ts:144`](../src/api/ConnectionString.ts)
+
+The string form of `jdbcProperties` is split on `;`. A value containing a literal semicolon will be incorrectly tokenised. Scope: document the restriction clearly in the option description rather than implement a full parser.
+
+- [ ] Update `DB2_OPTION_JDBC_PROPERTIES` description in `DB2Session.ts` to note "property values must not contain semicolons"
+
+---
+
+### H9 — No query timeout on `execFileSync`
+
+**File:** [`src/api/driver/JdbcDriver.ts:125`](../src/api/driver/JdbcDriver.ts)
+
+`execFileSync` has no `timeout` set, so a hung Db2 query blocks the CLI process indefinitely. Consider exposing `jdbcQueryTimeout` (milliseconds) as an optional session parameter.
+
+---
+
+### H10 — CI never exercises the compiled `.class` path
+
+**File:** [`scripts/buildJava.js`](../scripts/buildJava.js)
+
+If `javac` is absent from the CI image, `buildJava.js` silently skips compilation and the `.class` file is never produced. The runtime single-file launcher path is exercised, but the compiled path is not. Decide: install a JDK in CI (e.g. `actions/setup-java`) or document that compiled mode is validated only locally.
+
+---
+
+## Pre-Merge Gate
+
+Before squashing and opening the PR against `master`:
+
+- [ ] All items in **Must-Fix** are resolved
+- [ ] All items in **Should-Fix** are resolved or deferred with a filed issue
+- [ ] `npm run build` passes (TypeScript + `javac` or graceful fallback)
+- [ ] `npm run test:unit` passes with no new failures
+- [ ] `npm run lint` clean
+- [ ] This file is **deleted** from the branch

--- a/docs/jdbc_support.md
+++ b/docs/jdbc_support.md
@@ -1,0 +1,128 @@
+# JDBC Support in the IBM Db2 Plug-in for Zowe CLI
+
+Introduced in v6.1.17 as an opt-in alternative to the ODBC driver for environments where an ODBC license key is unavailable.
+
+---
+
+## Overview
+
+The plug-in will continue to default to the ODBC driver (`ibm_db` native binding). Setting `driverType: "jdbc"` in a profile or passing `--driver-type jdbc` on the CLI activates the JDBC pathway. Both paths implement the same [`IDB2Driver`](../src/api/driver/IDB2Driver.ts) interface, so all commands (`execute sql`, `export table`, `call procedure`) work identically regardless of driver.
+
+ODBC users with existing profiles are unaffected — `driverType` defaults to `"odbc"` when absent.
+
+---
+
+## How It Works
+
+When `driverType=jdbc`, the plug-in:
+
+1. Builds a JDBC connection URL from the session parameters — [`ConnectionString.buildJdbcUrl()`](../src/api/ConnectionString.ts)
+2. Resolves a JVM classpath from `jdbcJarPath`, `jdbcLicensePath`, and the bundled Java runner — [`JdbcDriver.buildClasspath()`](../src/api/driver/JdbcDriver.ts)
+3. Spawns a Java subprocess, passing credentials via **stdin** (never as process arguments, so they are not visible in `ps`/`/proc` listings) — [`JdbcDriver.runJavaCommand()`](../src/api/driver/JdbcDriver.ts)
+4. The Java runner ([`Db2JdbcRunner.java`](../src/java/Db2JdbcRunner.java)) connects, executes the action, and writes JSON results to stdout
+5. The Node.js side parses that JSON and returns it through `IDB2Driver`
+
+Driver selection is centralised in [`DB2DriverFactory.getDriver()`](../src/api/driver/DB2DriverFactory.ts).
+
+### Architecture
+
+```
+CLI handler
+    │
+    ▼
+DB2Session.createSessCfgFromArgs()   ← maps --driver-type, --jdbc-jar, etc. → IDB2Session
+    │
+    ▼
+SessionValidator.validate()          ← requires jdbcJarPath when driverType=jdbc
+    │
+    ▼
+DB2DriverFactory.getDriver()
+    ├── driverType=odbc  →  OdbcDriver   (ibm_db native binding)
+    └── driverType=jdbc  →  JdbcDriver
+                                │
+                                ▼
+                         ConnectionString.buildJdbcUrl()
+                                │
+                                ▼
+                         child_process.execFileSync("java", [...])
+                                │  stdin:  { user, password, args }
+                                │  stdout: JSON result
+                                ▼
+                         Db2JdbcRunner.java
+                           ├── execute    → SQL query / DML
+                           ├── call       → stored procedure
+                           └── getcolumns → DatabaseMetaData
+```
+
+---
+
+## Session Parameters
+
+| Parameter | CLI flag | Profile key | Required |
+|---|---|---|---|
+| `driverType` | `--driver-type jdbc` | `driverType` | Yes — must be `"jdbc"` |
+| `jdbcJarPath` | `--jdbc-jar <path>` | `jdbcJarPath` | Yes — must be an explicit path to `db2jcc4.jar` |
+| `jdbcLicensePath` | `--jdbc-license <path>` | `jdbcLicensePath` | Recommended — must be an explicit path to `db2jcc_license_cisuz.jar` |
+| `javaPath` | `--java-path <path>` | `javaPath` | No — defaults to `java` on PATH |
+| `jdbcProperties` | `--jdbc-props <key=val;...>` | `jdbcProperties` | No — additional JDBC URL properties |
+
+Both `jdbcJarPath` and `jdbcLicensePath` must point to an existing `.jar` file. Directory paths are not accepted — specify the full path to the JAR explicitly.
+
+Security-sensitive keys (`user`, `password`, `sslConnection`, `sslTrustStoreLocation`, `securityMechanism`) are blocked from `jdbcProperties` and always set directly by the plugin.
+
+---
+
+## SSL / TLS
+
+Pass `--ssl-file <path>` (profile key `sslFile`) with an absolute path to a certificate file. The plugin validates the path exists and injects `sslConnection=true` and `sslTrustStoreLocation=<path>` into the JDBC URL automatically.
+
+---
+
+## Zowe Team Config (`zowe.config.json`)
+
+The `zowe.config.schema.json` is generated at runtime by Zowe CLI from the Imperative profile definition in [`src/imperative.ts`](../src/imperative.ts) — it is not committed to the repository. All five JDBC properties are declared there and are included in the generated schema automatically when the plugin is installed.
+
+### Example profile
+
+```yaml
+profiles:
+  my-db2:
+    type: db2
+    properties:
+      host: db2.example.com
+      port: 50000
+      database: MYDB
+      driverType: jdbc
+      jdbcJarPath: /opt/ibm/db2/jdbc/db2jcc4.jar
+      jdbcLicensePath: /opt/ibm/db2/jdbc/db2jcc_license_cisuz.jar
+    secure:
+      - user
+      - password
+```
+
+### Example CLI invocation
+
+```bash
+zowe db2 execute sql "SELECT * FROM SYSIBM.SYSDUMMY1" \
+  --host db2.example.com --port 50000 \
+  --user myuser --password mypassword \
+  --database MYDB \
+  --driver-type jdbc \
+  --jdbc-jar /opt/ibm/db2/jdbc/db2jcc4.jar \
+  --jdbc-license /opt/ibm/db2/jdbc/db2jcc_license_cisuz.jar
+```
+
+---
+
+## Build
+
+At `npm run build`, [`scripts/buildJava.js`](../scripts/buildJava.js) compiles `src/java/Db2JdbcRunner.java` to `lib/java/Db2JdbcRunner.class` using `javac`. If `javac` is not on the PATH, the source file is copied to `lib/java/` instead and executed at runtime via the Java 11+ single-file source launcher (`java Db2JdbcRunner.java`). The `.class` path is always preferred when present.
+
+---
+
+## Backwards Compatibility
+
+- **ODBC users are unaffected.** `driverType` defaults to `"odbc"` in both `DB2Session.ts` and `createSessCfgFromArgs`. Existing profiles without `driverType` continue to use ODBC.
+- **No new required fields** are added to the profile schema for ODBC users.
+- **`IDB2Driver` interface** is the abstraction boundary — both drivers are interchangeable from the perspective of all API callers (`ExecuteSQL`, `CallSP`, `ExportTable`).
+- **`ibm_db` dependency is unchanged** — ODBC remains the default and the native binding is still required for ODBC mode.

--- a/docs/jdbc_testplan.md
+++ b/docs/jdbc_testplan.md
@@ -1,0 +1,182 @@
+# JDBC Test Plan
+
+Test coverage needed before the `jdbc-support` branch is merge-ready. Organised by layer — Java runner unit tests (JUnit or standalone), Node.js unit tests (Jest mocks), and live integration tests against the sandbox instance.
+
+---
+
+## 1. SQL Execution (`execute` action)
+
+### Unit (Jest — mock `execFileSync`)
+
+| Test | Input | Expected |
+|---|---|---|
+| Simple SELECT returns rows | `SELECT 1 FROM SYSIBM.SYSDUMMY1` | Result array with one row |
+| Multi-result-set query | SQL with two SELECTs separated by `;` | Two result sets yielded in order |
+| DML (INSERT/UPDATE/DELETE) | `INSERT INTO ...` | Empty result set, no error |
+| Empty result set | SELECT with no matching rows | Empty array, no error |
+| SQL syntax error | `SELEKT * FROM FOO` | `ImperativeError` with SQLCODE surfaced (H2) |
+| `execFileSync` throws with JSON stderr | Mock stderr as `{"error":true,"sqlcode":-204,"sqlstate":"42704","message":"..."}` | `ImperativeError` msg includes SQLCODE=-204 |
+| `execFileSync` throws with plain stderr | Mock stderr as raw Java stack | `ImperativeError` with stack stripped to first meaningful line |
+
+### Live (sandbox)
+
+| Test | Command | Expected |
+|---|---|---|
+| Row count | `SELECT COUNT(*) FROM SYSIBM.SYSTABLES` | Numeric result |
+| Multi-column row | `SELECT * FROM SYSIBM.SYSDUMMY1` | Row with `IBMREQD` column |
+| No-rows result | `SELECT * FROM SYSIBM.SYSTABLES WHERE NAME='ZZZNOMATCH'` | Empty result set, no error |
+
+---
+
+## 2. Stored Procedure — INPUT only (`call` action)
+
+### Unit (Jest)
+
+| Test | Input | Expected |
+|---|---|---|
+| No parameters | `CALL MYPROC()` | Calls `execFileSync` with `args=["MYPROC","[]"]` |
+| Single INPUT string | `ParamType:"INPUT", Data:"A00"` | Param JSON includes `ParamType:"INPUT"` |
+| Multiple INPUT params | Mixed string/integer DATA values | All params serialised in order |
+| INPUT with `DataType` set | `DataType:12` (VARCHAR) | `DataType` included in serialised JSON |
+
+### Live (sandbox)
+
+| Test | Proc | Expected |
+|---|---|---|
+| INPUT-only, result set | `JFLICKE.LISTTABLES()` | Returns table rows |
+
+---
+
+## 3. Stored Procedure — OUTPUT parameters
+
+### Unit (Jest)
+
+| Test | Input | Expected |
+|---|---|---|
+| `ParamType:"OUTPUT"` resolves correctly | Mock returns `{success:true,results:["VAL"]}` | `resolveParamType("OUTPUT")` → 2, result unpacked |
+| `ParamType:"INOUT"` resolves correctly | Mock returns `{success:true,results:["VAL"]}` | `resolveParamType("INOUT")` → 3, result unpacked |
+| Integer `ParamType:2` still works | Legacy numeric form | Resolves to OUTPUT without error |
+| `DataType` passthrough for DECIMAL | `ParamType:"OUTPUT", DataType:3` | `DataType:3` included in param JSON to runner |
+| `DataType` passthrough for INTEGER | `ParamType:"OUTPUT", DataType:4` | `DataType:4` included in param JSON to runner |
+| `DataType` defaults to VARCHAR when absent | `ParamType:"OUTPUT"` no DataType | Runner uses `Types.VARCHAR` (12) |
+| INOUT sets input then registers out | `ParamType:"INOUT", Data:"X", DataType:12` | `setObject` called then `registerOutParameter` |
+| `failureResponse` in runner response surfaced | Mock returns `{success:false,failureResponse:"SQLCODE=-440"}` | `ImperativeError` thrown with message |
+
+### Java unit (`Db2JdbcRunner` — isolated)
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `resolveParamType("INPUT")` | String "INPUT" | Returns 1 |
+| `resolveParamType("OUTPUT")` | String "OUTPUT" | Returns 2 |
+| `resolveParamType("INOUT")` | String "INOUT" | Returns 3 |
+| `resolveParamType("FILE")` | String "FILE" | Returns 1 (treated as INPUT) |
+| `resolveParamType(1)` | Integer 1 | Returns 1 |
+| `resolveParamType(2)` | Integer 2 | Returns 2 |
+| `resolveParamType(3)` | Integer 3 | Returns 3 |
+| `resolveParamType(null)` | null | Returns 1 (default) |
+
+### Live (sandbox)
+
+| Test | Proc / params | Expected |
+|---|---|---|
+| DECIMAL OUT | `JFLICKE.TOTALSALARY("A00", OUT DECIMAL, OUT INTEGER)` | Two numeric OUT values returned |
+| VARCHAR OUT | Proc with VARCHAR OUT | String value returned |
+| INOUT round-trip | Proc with INOUT param | Output value differs from input |
+
+---
+
+## 4. SQL Type Mapping (`java.sql.Types` codes)
+
+Key codes a caller may need to pass as `DataType`:
+
+| `DataType` value | `java.sql.Types` constant | Db2 type |
+|---|---|---|
+| 2 | `NUMERIC` | NUMERIC |
+| 3 | `DECIMAL` | DECIMAL |
+| 4 | `INTEGER` | INTEGER |
+| 5 | `SMALLINT` | SMALLINT |
+| 6 | `FLOAT` | FLOAT |
+| 8 | `DOUBLE` | DOUBLE |
+| 12 | `VARCHAR` | VARCHAR (default) |
+| 1 | `CHAR` | CHAR |
+| 91 | `DATE` | DATE |
+| 92 | `TIME` | TIME |
+| 93 | `TIMESTAMP` | TIMESTAMP |
+| -2 | `BINARY` | CHAR FOR BIT DATA |
+| -3 | `VARBINARY` | VARCHAR FOR BIT DATA |
+
+These should be documented in `IDB2Parameter.DataType` JSDoc so users know what to pass.
+
+---
+
+## 5. Binary / ROWID Column Rendering (H11)
+
+### Unit (Jest)
+
+| Test | Mock output | Expected |
+|---|---|---|
+| `byte[]` column renders as hex | Runner returns `[B@abc123` style | After fix: hex string like `"0xDEADBEEF"` |
+
+### Java unit
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `byte[]` value in result set | Column of type ROWID | Emitted as hex string in JSON, not `[B@...` |
+
+### Live (sandbox)
+
+| Test | Query | Expected |
+|---|---|---|
+| SYSIBM.SYSTABLES CHECKRID column | `SELECT CHECKRID FROM SYSIBM.SYSTABLES FETCH FIRST 1 ROW ONLY` | Hex string, not `[B@...` |
+
+---
+
+## 6. Error Handling (H2)
+
+### Unit (Jest)
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `SQLException` with SQLCODE | Runner emits `{"error":true,"sqlcode":-204,"sqlstate":"42704","message":"..."}` on stderr | `ImperativeError` contains SQLCODE and SQLSTATE |
+| Connection failure | Bad host | `ImperativeError` with clean message, no stack trace |
+| Auth failure | Bad password | `ImperativeError` with `SQLCODE=-4214` |
+| Compiler warning stripped | stderr contains `warning: [unchecked]` prefix | Warning lines not included in error message |
+
+### Live (sandbox)
+
+| Test | Scenario | Expected |
+|---|---|---|
+| Bad table name | `SELECT * FROM JFLICKE.NOTEXIST` | Error with SQLCODE=-204 surfaced cleanly |
+| Bad SQL syntax | `SELEKT 1` | Error with SQLCODE=-104 surfaced cleanly |
+
+---
+
+## 7. Connection / Session
+
+### Unit (Jest)
+
+| Test | Scenario | Expected |
+|---|---|---|
+| JDBC URL built correctly | host/port/database set | `jdbc:db2://host:port/db` |
+| SSL injected into URL | `sslFile` set to existing file | URL contains `sslConnection=true;sslTrustStoreLocation=...` |
+| `jdbcJarPath` missing | `driverType=jdbc`, no jar | `SessionValidator` throws before JVM spawned |
+| `jdbcJarPath` is directory | Path is a dir | `SessionValidator` throws with "must be a path to a .jar file" |
+| Blocked `jdbcProperties` key | `user=hacker` in props | `ConnectionString.buildJdbcUrl` throws |
+
+---
+
+## 8. Export Table (JDBC path)
+
+### Unit (Jest)
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `getTableRows` yields rows | Mock returns `[[{COL:"VAL1"},{COL:"VAL2"}]]` | Two rows yielded in order |
+| `getTableColumns` returns metadata | Mock returns column array | Columns returned as `IDB2Column[]` |
+| Empty table | Mock returns `[[]]` | Zero rows, no error |
+
+### Live (sandbox)
+
+| Test | Command | Expected |
+|---|---|---|
+| Export JFLICKE table | `zowe db2 export table JFLICKE.EMP` | CSV output with headers |

--- a/docs/jdbc_testplan.md
+++ b/docs/jdbc_testplan.md
@@ -1,66 +1,113 @@
 # JDBC Test Plan
 
-Test coverage needed before the `jdbc-support` branch is merge-ready. Organised by layer — Java runner unit tests (JUnit or standalone), Node.js unit tests (Jest mocks), and live integration tests against the sandbox instance.
+Test coverage needed before the `jdbc-support` branch is merge-ready.
+
+---
+
+## Test layers
+
+| Layer | Location | Trigger |
+|---|---|---|
+| Unit (Jest, mocked) | `__tests__/api/`, `__tests__/cli/` | `npm run test:unit` — always runs, no live connection needed |
+| Integration (live Db2) | `__tests__/__integration__/` | `npm run test:integration` — opt-in; skipped automatically if `custom_properties.yaml` absent |
+| Formal system tests | `__tests__/__system__/` | `npm run test:system` — requires `custom_properties.yaml` and managed Zowe home |
+
+**Unit test rule:** new JDBC-specific params (`jdbcJarPath`, `jdbcLicensePath`, `javaPath`, `jdbcProperties`, `driverType`) should extend **existing** test files rather than create new ones.
+
+---
+
+## Integration Test Infrastructure
+
+### How live tests run
+
+- Tests live under `__tests__/__integration__/` — separate from `__tests__/__system__/`
+- Shell scripts issue `zowe db2 ...` commands via `TestEnvironment.setUp` (same pattern as system tests), which reads `custom_properties.yaml`, creates a temp `db2` profile, and sets the working directory
+- `custom_properties.yaml` is gitignored; the full suite skips automatically if the file is absent
+- Requires the plugin to be built and installed first: `npm run build && zowe plugins install .`
+- **ODBC path** cannot be live-tested without the IBM Data Server Driver license — ODBC remains unit-test-only (mocked). All integration tests use JDBC via `driverType: jdbc` in the profile
+
+### Type-mapping stored procedure (`TYPESMAP`)
+
+The call integration tests depend on a stored procedure that echo-maps every supported Db2 type through IN→OUT parameters. It is created under the **current user's schema** in `beforeAll` and dropped in `afterAll`.
+
+> ⚠️ `CREATE PROCEDURE` with `LANGUAGE SQL` requires a WLM environment on z/OS subsystems. On the sandbox (`DB2D`), this fails with `SQLCODE=-20071`. The `TYPESMAP` tests are written but blocked pending either DBA pre-creation of the proc or access to a subsystem where the user has `CREATE PROCEDURE` permission.
+
+> `TIMESTAMP WITH TIMEZONE` is excluded — z/OS-specific handling in the Java runner needs separate investigation.
 
 ---
 
 ## 1. SQL Execution (`execute` action)
 
-### Unit (Jest — mock `execFileSync`)
+### Unit — `__tests__/api/DriverFactory.test.ts`
 
+Already implemented:
+- `OdbcDriver` instantiated when `driverType` is `"odbc"` or absent
+- `JdbcDriver` instantiated when `driverType` is `"jdbc"`
+- `JdbcDriver.execute` calls `execFileSync` and returns parsed results
+- `JdbcDriver.callSP` calls `execFileSync` and returns response object
+- `JdbcDriver.getTableColumns` calls `execFileSync` and returns column metadata
+- `JdbcDriver.buildClasspath` includes jar paths
+
+Still needed:
 | Test | Input | Expected |
 |---|---|---|
-| Simple SELECT returns rows | `SELECT 1 FROM SYSIBM.SYSDUMMY1` | Result array with one row |
-| Multi-result-set query | SQL with two SELECTs separated by `;` | Two result sets yielded in order |
-| DML (INSERT/UPDATE/DELETE) | `INSERT INTO ...` | Empty result set, no error |
+| Multi-result-set query | SQL with two SELECTs | Two result sets yielded in order |
+| DML with no result set | `INSERT INTO ...` | Empty array, no error |
 | Empty result set | SELECT with no matching rows | Empty array, no error |
-| SQL syntax error | `SELEKT * FROM FOO` | `ImperativeError` with SQLCODE surfaced (H2) |
-| `execFileSync` throws with JSON stderr | Mock stderr as `{"error":true,"sqlcode":-204,"sqlstate":"42704","message":"..."}` | `ImperativeError` msg includes SQLCODE=-204 |
-| `execFileSync` throws with plain stderr | Mock stderr as raw Java stack | `ImperativeError` with stack stripped to first meaningful line |
+| `execFileSync` throws with JSON stderr | `{"error":true,"sqlcode":-204,...}` | `ImperativeError` with SQLCODE surfaced |
+| `execFileSync` throws with plain stderr | Raw Java stack | `ImperativeError` thrown |
 
-### Live (sandbox)
+### Integration — `__tests__/__integration__/db2.execute.integration.test.ts`
 
-| Test | Command | Expected |
+| Test | Status | Notes |
 |---|---|---|
-| Row count | `SELECT COUNT(*) FROM SYSIBM.SYSTABLES` | Numeric result |
-| Multi-column row | `SELECT * FROM SYSIBM.SYSDUMMY1` | Row with `IBMREQD` column |
-| No-rows result | `SELECT * FROM SYSIBM.SYSTABLES WHERE NAME='ZZZNOMATCH'` | Empty result set, no error |
+| Smoke test: `SELECT 1 FROM SYSIBM.SYSDUMMY1` | ✅ passing | |
+| Row count: `SELECT COUNT(*) FROM SYSIBM.SYSTABLES` | ✅ passing | |
+| No-rows result | ✅ passing | |
+| String types: CHAR, VARCHAR | ✅ passing | |
+| Numeric types: SMALLINT, INTEGER, BIGINT, DECIMAL, REAL, DOUBLE | ✅ passing | |
+| Date/time types: DATE, TIME, TIMESTAMP | ✅ passing | |
+| Bad SQL returns non-zero exit | ✅ passing | |
 
 ---
 
 ## 2. Stored Procedure — INPUT only (`call` action)
 
-### Unit (Jest)
+### Unit — `__tests__/api/DriverFactory.test.ts`
 
+Already implemented:
+- `JdbcDriver.callSP` calls `execFileSync` and returns response object
+
+Still needed:
 | Test | Input | Expected |
 |---|---|---|
-| No parameters | `CALL MYPROC()` | Calls `execFileSync` with `args=["MYPROC","[]"]` |
+| No parameters | `CALL MYPROC()` | `execFileSync` called with empty params array |
 | Single INPUT string | `ParamType:"INPUT", Data:"A00"` | Param JSON includes `ParamType:"INPUT"` |
-| Multiple INPUT params | Mixed string/integer DATA values | All params serialised in order |
+| Multiple INPUT params | Mixed string/integer values | All params serialised in order |
 | INPUT with `DataType` set | `DataType:12` (VARCHAR) | `DataType` included in serialised JSON |
 
-### Live (sandbox)
+### Integration — `__tests__/__integration__/db2.call.integration.test.ts`
 
-| Test | Proc | Expected |
+| Test | Status | Notes |
 |---|---|---|
-| INPUT-only, result set | `JFLICKE.LISTTABLES()` | Returns table rows |
+| String OUT params round-trip (CHAR, VARCHAR) | ❌ blocked | `CREATE PROCEDURE` fails `SQLCODE=-20071` on sandbox |
+| Numeric OUT params round-trip | ❌ blocked | Same |
+| Date/time OUT params round-trip | ❌ blocked | Same |
 
 ---
 
 ## 3. Stored Procedure — OUTPUT parameters
 
-### Unit (Jest)
+### Unit — `__tests__/api/DriverFactory.test.ts`
 
+Still needed:
 | Test | Input | Expected |
 |---|---|---|
-| `ParamType:"OUTPUT"` resolves correctly | Mock returns `{success:true,results:["VAL"]}` | `resolveParamType("OUTPUT")` → 2, result unpacked |
-| `ParamType:"INOUT"` resolves correctly | Mock returns `{success:true,results:["VAL"]}` | `resolveParamType("INOUT")` → 3, result unpacked |
-| Integer `ParamType:2` still works | Legacy numeric form | Resolves to OUTPUT without error |
-| `DataType` passthrough for DECIMAL | `ParamType:"OUTPUT", DataType:3` | `DataType:3` included in param JSON to runner |
-| `DataType` passthrough for INTEGER | `ParamType:"OUTPUT", DataType:4` | `DataType:4` included in param JSON to runner |
-| `DataType` defaults to VARCHAR when absent | `ParamType:"OUTPUT"` no DataType | Runner uses `Types.VARCHAR` (12) |
-| INOUT sets input then registers out | `ParamType:"INOUT", Data:"X", DataType:12` | `setObject` called then `registerOutParameter` |
-| `failureResponse` in runner response surfaced | Mock returns `{success:false,failureResponse:"SQLCODE=-440"}` | `ImperativeError` thrown with message |
+| `ParamType:"OUTPUT"` passes through to runner | Mock `{success:true,results:["VAL"]}` | `ParamType:"OUTPUT"` in stdin JSON |
+| `ParamType:"INOUT"` passes through to runner | Mock `{success:true,results:["VAL"]}` | `ParamType:"INOUT"` in stdin JSON |
+| Legacy numeric `ParamType:2` passes through | Integer form | Unchanged in serialised JSON |
+| `DataType` for DECIMAL (3) passes through | `ParamType:"OUTPUT", DataType:3` | `DataType:3` in param JSON |
+| `failureResponse` surfaced as `ImperativeError` | `{success:false,failureResponse:"SQLCODE=-440"}` | `ImperativeError` thrown |
 
 ### Java unit (`Db2JdbcRunner` — isolated)
 
@@ -70,18 +117,8 @@ Test coverage needed before the `jdbc-support` branch is merge-ready. Organised 
 | `resolveParamType("OUTPUT")` | String "OUTPUT" | Returns 2 |
 | `resolveParamType("INOUT")` | String "INOUT" | Returns 3 |
 | `resolveParamType("FILE")` | String "FILE" | Returns 1 (treated as INPUT) |
-| `resolveParamType(1)` | Integer 1 | Returns 1 |
-| `resolveParamType(2)` | Integer 2 | Returns 2 |
-| `resolveParamType(3)` | Integer 3 | Returns 3 |
+| `resolveParamType(1/2/3)` | Integer form | Returns correct int |
 | `resolveParamType(null)` | null | Returns 1 (default) |
-
-### Live (sandbox)
-
-| Test | Proc / params | Expected |
-|---|---|---|
-| DECIMAL OUT | `JFLICKE.TOTALSALARY("A00", OUT DECIMAL, OUT INTEGER)` | Two numeric OUT values returned |
-| VARCHAR OUT | Proc with VARCHAR OUT | String value returned |
-| INOUT round-trip | Proc with INOUT param | Output value differs from input |
 
 ---
 
@@ -91,6 +128,7 @@ Key codes a caller may need to pass as `DataType`:
 
 | `DataType` value | `java.sql.Types` constant | Db2 type |
 |---|---|---|
+| 1 | `CHAR` | CHAR |
 | 2 | `NUMERIC` | NUMERIC |
 | 3 | `DECIMAL` | DECIMAL |
 | 4 | `INTEGER` | INTEGER |
@@ -98,7 +136,7 @@ Key codes a caller may need to pass as `DataType`:
 | 6 | `FLOAT` | FLOAT |
 | 8 | `DOUBLE` | DOUBLE |
 | 12 | `VARCHAR` | VARCHAR (default) |
-| 1 | `CHAR` | CHAR |
+| -5 | `BIGINT` | BIGINT |
 | 91 | `DATE` | DATE |
 | 92 | `TIME` | TIME |
 | 93 | `TIMESTAMP` | TIMESTAMP |
@@ -123,7 +161,7 @@ These should be documented in `IDB2Parameter.DataType` JSDoc so users know what 
 |---|---|---|
 | `byte[]` value in result set | Column of type ROWID | Emitted as hex string in JSON, not `[B@...` |
 
-### Live (sandbox)
+### Integration
 
 | Test | Query | Expected |
 |---|---|---|
@@ -133,50 +171,58 @@ These should be documented in `IDB2Parameter.DataType` JSDoc so users know what 
 
 ## 6. Error Handling (H2)
 
-### Unit (Jest)
+### Unit (Jest) — `__tests__/api/DriverFactory.test.ts`
 
+Still needed:
 | Test | Scenario | Expected |
 |---|---|---|
-| `SQLException` with SQLCODE | Runner emits `{"error":true,"sqlcode":-204,"sqlstate":"42704","message":"..."}` on stderr | `ImperativeError` contains SQLCODE and SQLSTATE |
-| Connection failure | Bad host | `ImperativeError` with clean message, no stack trace |
-| Auth failure | Bad password | `ImperativeError` with `SQLCODE=-4214` |
-| Compiler warning stripped | stderr contains `warning: [unchecked]` prefix | Warning lines not included in error message |
+| `SQLException` with SQLCODE | Runner emits `{"error":true,"sqlcode":-204,...}` on stderr | `ImperativeError` contains SQLCODE and SQLSTATE |
+| `execFileSync` throws with plain stderr | Raw Java stack | `ImperativeError` thrown with cleaned message |
 
-### Live (sandbox)
+### Integration
 
-| Test | Scenario | Expected |
+| Test | Status | Notes |
 |---|---|---|
-| Bad table name | `SELECT * FROM JFLICKE.NOTEXIST` | Error with SQLCODE=-204 surfaced cleanly |
-| Bad SQL syntax | `SELEKT 1` | Error with SQLCODE=-104 surfaced cleanly |
+| Bad SQL syntax returns non-zero exit | ✅ passing | Covered in execute suite |
 
 ---
 
 ## 7. Connection / Session
 
-### Unit (Jest)
+### Unit — `__tests__/api/ConnectionString.test.ts` and `__tests__/api/SessionValidator.test.ts`
 
-| Test | Scenario | Expected |
-|---|---|---|
-| JDBC URL built correctly | host/port/database set | `jdbc:db2://host:port/db` |
-| SSL injected into URL | `sslFile` set to existing file | URL contains `sslConnection=true;sslTrustStoreLocation=...` |
-| `jdbcJarPath` missing | `driverType=jdbc`, no jar | `SessionValidator` throws before JVM spawned |
-| `jdbcJarPath` is directory | Path is a dir | `SessionValidator` throws with "must be a path to a .jar file" |
-| Blocked `jdbcProperties` key | `user=hacker` in props | `ConnectionString.buildJdbcUrl` throws |
+Already implemented:
+- JDBC URL built correctly from session (`buildJdbcUrlFromSession`)
+- SSL injected into URL when `sslFile` set to existing file
+- `sslFile` does not exist → throws
+- Blocked `jdbcProperties` key (`user=hacker`) → throws
+- `driverType: "jdbc"` with missing `jdbcJarPath` → throws
+- `jdbcJarPath` does not exist → throws
+- `jdbcJarPath` is a directory → throws
+- `jdbcLicensePath` is a directory → throws
+- Invalid `driverType` → throws
+
+No additional unit tests needed for this section.
 
 ---
 
 ## 8. Export Table (JDBC path)
 
-### Unit (Jest)
+### Unit — `__tests__/api/DriverFactory.test.ts`
 
+Already implemented:
+- `getTableColumns` calls `execFileSync` and returns column metadata
+
+Still needed:
 | Test | Scenario | Expected |
 |---|---|---|
 | `getTableRows` yields rows | Mock returns `[[{COL:"VAL1"},{COL:"VAL2"}]]` | Two rows yielded in order |
-| `getTableColumns` returns metadata | Mock returns column array | Columns returned as `IDB2Column[]` |
-| Empty table | Mock returns `[[]]` | Zero rows, no error |
+| Empty table export | Mock returns `[[]]` | Zero rows, no error |
 
-### Live (sandbox)
+### Integration
+
+Skipped automatically if `custom_properties.yaml` is absent.
 
 | Test | Command | Expected |
 |---|---|---|
-| Export JFLICKE table | `zowe db2 export table JFLICKE.EMP` | CSV output with headers |
+| Export SYSIBM table | `zowe db2 export table SYSIBM.SYSDUMMY1` | CSV output with headers, at least one row |

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -466,6 +466,32 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@dabh/diagnostics": {
       "version": "2.0.3",
       "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
@@ -885,6 +911,17 @@
         }
       }
     },
+    "node_modules/@jest/core/node_modules/diff": {
+      "version": "4.0.4",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/@jest/core/node_modules/jest-config": {
       "version": "29.7.0",
       "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
@@ -927,6 +964,62 @@
         "ts-node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@jest/core/node_modules/ts-node": {
+      "version": "10.9.2",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/yn": {
+      "version": "3.1.1",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@jest/environment": {
@@ -1262,6 +1355,38 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.13",
+      "integrity": "sha512-gcLdvR9HO1ZJBypsOGqaP6TFEzb6vIta0KSTLt9NAQ6pXQO3cRgSVyCN6pzYqI9DlJgY71XKO0dpDhCf08b3pg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2021,6 +2146,20 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/adm-zip": {
       "version": "0.5.16",
       "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
@@ -2132,6 +2271,14 @@
       "version": "2.2.0",
       "integrity": "sha512-gkco+qxENJV+8vFcDiiFhuoSvRXb2a/QPqpSoWhVz829VNJfOTnELbBmPmNKFxf3xdNnw4DWCkzkDaavcX/1YQ==",
       "dev": true
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -2878,6 +3025,17 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/create-jest/node_modules/diff": {
+      "version": "4.0.4",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/create-jest/node_modules/jest-config": {
       "version": "29.7.0",
       "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
@@ -2921,6 +3079,70 @@
           "optional": true
         }
       }
+    },
+    "node_modules/create-jest/node_modules/ts-node": {
+      "version": "10.9.2",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/create-jest/node_modules/yn": {
+      "version": "3.1.1",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5084,6 +5306,17 @@
         }
       }
     },
+    "node_modules/jest-cli/node_modules/diff": {
+      "version": "4.0.4",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/jest-cli/node_modules/jest-config": {
       "version": "29.7.0",
       "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
@@ -5126,6 +5359,62 @@
         "ts-node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jest-cli/node_modules/ts-node": {
+      "version": "10.9.2",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-cli/node_modules/yn": {
+      "version": "3.1.1",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/jest-diff": {
@@ -8295,6 +8584,14 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "prebuild": "npm run clean && npm run lint && echo Using TypeScript && tsc --version",
-    "build": "node scripts/updateLicense.js && tsc --pretty && npm run checkTestsCompile && npm run circularDependencyCheck",
+    "build": "node scripts/updateLicense.js && node scripts/buildJava.js && tsc --pretty && npm run checkTestsCompile && npm run circularDependencyCheck",
     "checkTestsCompile": "echo \"Checking that test source compiles...\" && tsc --project __tests__/test-tsconfig.json --noEmit",
     "circularDependencyCheck": "madge -c lib",
     "clean": "rimraf lib",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "lint:tests": "eslint \"**/__tests__/**/*.ts\"",
     "test": "npm run test:unit && npm run test:system",
     "test:system": "env-cmd -f __tests__/__resources__/env/system.env jest .*/__system__/.* --coverage false --runInBand",
-    "test:unit": "env-cmd -f __tests__/__resources__/env/unit.env jest --coverage --testPathIgnorePatterns \".*/__system__/.*\" ",
+    "test:unit": "env-cmd -f __tests__/__resources__/env/unit.env jest --coverage --testPathIgnorePatterns \".*/__system__/.*\" \".*/__integration__/.*\"",
+    "test:integration": "jest .*/__integration__/.* --coverage false --runInBand",
     "installPlugin": "npm install && npm run clean && npm run build && bright plugins install .",
     "typedoc": "typedoc --out ./docs/typedoc/ ./src/ --disableOutputCheck"
   },

--- a/scripts/buildJava.js
+++ b/scripts/buildJava.js
@@ -1,0 +1,36 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+const fs = require("fs");
+const path = require("path");
+const child_process = require("child_process");
+
+const srcJavaDir = path.resolve(__dirname, "../src/java");
+const libJavaDir = path.resolve(__dirname, "../lib/java");
+
+if (!fs.existsSync(libJavaDir)) {
+    fs.mkdirSync(libJavaDir, { recursive: true });
+}
+
+// Copy Java source file to lib/java/
+const srcFile = path.join(srcJavaDir, "Db2JdbcRunner.java");
+const destFile = path.join(libJavaDir, "Db2JdbcRunner.java");
+if (fs.existsSync(srcFile)) {
+    fs.copyFileSync(srcFile, destFile);
+}
+
+// Attempt to compile with javac if available
+try {
+    child_process.execSync(`javac -d "${libJavaDir}" "${destFile}"`, { stdio: "ignore" });
+    console.log("Db2JdbcRunner compiled successfully to lib/java.");
+} catch (err) {
+    console.log("javac not found or compilation skipped; Db2JdbcRunner.java source file copied for runtime execution.");
+}

--- a/scripts/buildJava.js
+++ b/scripts/buildJava.js
@@ -29,8 +29,16 @@ if (fs.existsSync(srcFile)) {
 
 // Attempt to compile with javac if available
 try {
-    child_process.execSync(`javac -d "${libJavaDir}" "${destFile}"`, { stdio: "ignore" });
+    child_process.execFileSync("javac", ["-d", libJavaDir, destFile], { stdio: ["ignore", "ignore", "pipe"] });
     console.log("Db2JdbcRunner compiled successfully to lib/java.");
 } catch (err) {
-    console.log("javac not found or compilation skipped; Db2JdbcRunner.java source file copied for runtime execution.");
+    if (err.code === "ENOENT") {
+        // javac not on PATH — source file is in place for the Java 11+ single-file launcher
+        console.log("javac not found; Db2JdbcRunner.java source file copied for runtime execution.");
+    } else {
+        // Actual compilation failure — surface the error so the build doesn't silently break
+        const stderr = err.stderr ? err.stderr.toString().trim() : err.message;
+        console.error("Db2JdbcRunner compilation failed:\n" + stderr);
+        process.exit(1);
+    }
 }

--- a/src/api/CallSP.ts
+++ b/src/api/CallSP.ts
@@ -9,17 +9,14 @@
 *                                                                                 *
 */
 
-import * as ibmdb from "ibm_db";
 import { IDB2Session } from "../rest/session/doc/IDB2Session";
-import { DB2_PARM_INOUT, DB2_PARM_INPUT, DB2_PARM_OUTPUT, IDB2Parameter } from "./doc/IDB2Parameter";
+import { IDB2Parameter } from "./doc/IDB2Parameter";
 import { IDB2Response } from "./doc/IDB2Response";
 import { SessionValidator } from "./SessionValidator";
-import { ConnectionString } from "./ConnectionString";
-import { DB2Error } from "./DB2Error";
-import { DB2Constants } from "./DB2Constants";
+import { DB2DriverFactory } from "./driver/DB2DriverFactory";
 
 /**
- * Class to handle the invocation of the stored procedures
+ * Class to handle the invocation of stored procedures
  * @export
  * @class CallSP
  */
@@ -36,68 +33,13 @@ export class CallSP {
      */
     public static callCommon(session: IDB2Session, routineName: string, parameters?: IDB2Parameter[]): IDB2Response {
         SessionValidator.validate(session);
-        const connectionString = ConnectionString.buildFromSession(session);
-        const options = {
-            fetchMode: DB2Constants.FETCH_MODE_ARRAY,
-        };
-        const response: IDB2Response = {
-            success: false,
-            results: [],
-            failureResponse: undefined,
-        };
-        const query: string = `CALL ${routineName}`;
-        let result: any;
-        let outVarCount: number = 0;
-        const newParameters: ibmdb.SQLParam[] = [];
-        // Count parameters with type OUTPUT or INOUT as they will be returned in the result set.
-        if (parameters != null) {
-            for (const parameter of parameters) {
-                if (parameter.ParamType === DB2_PARM_INOUT || parameter.ParamType === DB2_PARM_OUTPUT) {
-                    outVarCount++;
-                }
-                if (parameter.ParamType == undefined) { parameter.ParamType = DB2_PARM_INPUT; }
-                newParameters.push(parameter as ibmdb.SQLParam);
-            }
-        }
-
-        try {
-            const db2 = ibmdb.openSync(connectionString, options);
-            // Prepare and execute the statement
-            const preparedStatement = db2.prepareSync(query);
-            result = preparedStatement.executeSync(newParameters);
-            // Extract INOUT and OUTPUT parameters
-            if (outVarCount !== 0 && Array.isArray(result)) {
-                // If there are OUT/INOUT parameters, then ODBC driver returns an array, where
-                //   - element with index 0 is the ODBSResult
-                //   - element with index 1 is an array of INOUT/OUTPUT parameters
-                while (outVarCount > 0) {
-                    response.results.push(result[1].shift());
-                    outVarCount--;
-                }
-                result = result[0];
-            }
-            const data = result.fetchAllSync();
-            // Rest is the result set
-            if (data.length) {
-                response.results.push(data);
-            }
-            // Retrieve all other result sets
-            while (result.moreResultsSync()) {
-                response.results.push(result.fetchAllSync());
-            }
-            response.success = true;
-            result.closeSync();
-            db2.closeSync();
-        }
-        catch (err) {
-            DB2Error.process(err);
-        }
-        return response;
+        const driver = DB2DriverFactory.getDriver(session);
+        return driver.callSP(routineName, parameters) as IDB2Response;
     }
 
     /**
      * Call a stored procedure
-     * @param {IDB2Session} session session DB2 session parameters
+     * @param {IDB2Session} session DB2 session parameters
      * @param {string} routineName Name of the stored procedure to call
      * @param {IDB2Parameter} parameters Parameters to bind to the SQL statement
      * @returns {IDB2Response}

--- a/src/api/ConnectionString.ts
+++ b/src/api/ConnectionString.ts
@@ -9,8 +9,16 @@
 *                                                                                 *
 */
 
+import * as fs from "fs";
+import * as path from "path";
 import { IDB2Session } from "../";
 import { DB2Constants } from "./DB2Constants";
+
+/**
+ * JDBC properties that must not be overridden by user-supplied jdbcProperties,
+ * as they are set explicitly by the plugin (credentials, SSL config).
+ */
+const BLOCKED_JDBC_KEYS = new Set(["user", "password", "ssltruststorelocation", "sslconnection", "securitymechanism"]);
 
 /**
  * DB2 server APIs
@@ -102,9 +110,11 @@ export class ConnectionString {
      * @param {string} hostname Host name
      * @param {number} port Port number
      * @param {string} database Database name
-     * @param {string} sslFile SSL certificate file path
+     * @param {string} sslFile SSL certificate file path — must be an absolute path to an existing file
      * @param {string | Record<string, string>} jdbcProperties Additional JDBC properties
      * @returns {string}
+     * @throws {Error} if sslFile is not an absolute path to an existing file, or if jdbcProperties
+     *   attempts to shadow a security-sensitive key (user, password, sslConnection, etc.)
      */
     public static buildJdbcUrl(
         hostname?: string,
@@ -120,17 +130,36 @@ export class ConnectionString {
         const props: string[] = [];
 
         if (sslFile) {
-            props.push(`sslConnection=true`, `sslTrustStoreLocation=${sslFile}`);
+            // Guard against path traversal — require an absolute path to an existing file
+            const resolved = path.resolve(sslFile);
+            if (!fs.existsSync(resolved) || !fs.statSync(resolved).isFile()) {
+                throw new Error(`sslFile must be an absolute path to an existing certificate file: ${sslFile}`);
+            }
+            props.push(`sslConnection=true`, `sslTrustStoreLocation=${resolved}`);
         }
 
         if (jdbcProperties) {
+            const pairs: Array<[string, string]> = [];
             if (typeof jdbcProperties === "string") {
-                const pairs = jdbcProperties.split(";").map(s => s.trim()).filter(Boolean);
-                props.push(...pairs);
-            } else if (typeof jdbcProperties === "object") {
-                for (const [k, v] of Object.entries(jdbcProperties)) {
-                    props.push(`${k}=${v}`);
+                for (const token of jdbcProperties.split(";").map(s => s.trim()).filter(Boolean)) {
+                    const eq = token.indexOf("=");
+                    if (eq === -1) { pairs.push([token, ""]); } else {
+                        pairs.push([token.substring(0, eq), token.substring(eq + 1)]);
+                    }
                 }
+            } else {
+                for (const [k, v] of Object.entries(jdbcProperties)) {
+                    pairs.push([k, v]);
+                }
+            }
+            for (const [k, v] of pairs) {
+                if (BLOCKED_JDBC_KEYS.has(k.toLowerCase())) {
+                    throw new Error(
+                        `jdbcProperties must not override security-sensitive key '${k}'. ` +
+                        `Remove it from jdbcProperties; the plugin sets it directly.`
+                    );
+                }
+                props.push(`${k}=${v}`);
             }
         }
 

--- a/src/api/ConnectionString.ts
+++ b/src/api/ConnectionString.ts
@@ -10,6 +10,7 @@
 */
 
 import { IDB2Session } from "../";
+import { DB2Constants } from "./DB2Constants";
 
 /**
  * DB2 server APIs
@@ -78,6 +79,65 @@ export class ConnectionString {
             connectionString += `Security=SSL;SSLServerCertificate=${sslFile};`;
         }
         return connectionString;
+    }
+
+    /**
+     * Build the JDBC connection URL from a Session object
+     * @param {IDB2Session} session Connection values
+     * @returns {string}
+     * @memberof ConnectionString
+     */
+    public static buildJdbcUrlFromSession(session: IDB2Session): string {
+        return ConnectionString.buildJdbcUrl(
+            session.hostname,
+            session.port,
+            session.database,
+            session.sslFile,
+            session.jdbcProperties
+        );
+    }
+
+    /**
+     * Build the JDBC connection URL
+     * @param {string} hostname Host name
+     * @param {number} port Port number
+     * @param {string} database Database name
+     * @param {string} sslFile SSL certificate file path
+     * @param {string | Record<string, string>} jdbcProperties Additional JDBC properties
+     * @returns {string}
+     */
+    public static buildJdbcUrl(
+        hostname?: string,
+        port?: number,
+        database?: string,
+        sslFile?: string,
+        jdbcProperties?: string | Record<string, string>
+    ): string {
+        const host = hostname || "localhost";
+        const p = port || DB2Constants.DEFAULT_DB2_PORT;
+        const db = database || "";
+        let url = `jdbc:db2://${host}:${p}/${db}`;
+        const props: string[] = [];
+
+        if (sslFile) {
+            props.push(`sslConnection=true`, `sslTrustStoreLocation=${sslFile}`);
+        }
+
+        if (jdbcProperties) {
+            if (typeof jdbcProperties === "string") {
+                const pairs = jdbcProperties.split(";").map(s => s.trim()).filter(Boolean);
+                props.push(...pairs);
+            } else if (typeof jdbcProperties === "object") {
+                for (const [k, v] of Object.entries(jdbcProperties)) {
+                    props.push(`${k}=${v}`);
+                }
+            }
+        }
+
+        if (props.length > 0) {
+            url += ":" + props.join(";") + ";";
+        }
+        return url;
     }
 
 }

--- a/src/api/DB2Constants.ts
+++ b/src/api/DB2Constants.ts
@@ -19,4 +19,5 @@ import { FETCH_ARRAY, FETCH_OBJECT } from "ibm_db";
 export class DB2Constants {
     public static readonly FETCH_MODE_ARRAY = FETCH_ARRAY;
     public static readonly FETCH_MODE_OBJECT = FETCH_OBJECT;
+    public static readonly DEFAULT_DB2_PORT = 50000;
 }

--- a/src/api/DB2Error.ts
+++ b/src/api/DB2Error.ts
@@ -12,7 +12,7 @@
 import { IImperativeError, ImperativeError, TextUtils } from "@zowe/imperative";
 
 /**
- * Class to handle DB2 ODBC Driver errors
+ * Class to handle DB2 driver errors (ODBC & JDBC)
  * @export
  * @class DB2Error
  */
@@ -20,16 +20,27 @@ export class DB2Error {
 
     /**
      * Prettify the error message
-     * @param {any} original The original error catched
+     * @param {any} original The original error caught
      */
     public static process(original: any) {
+        if (!original) {
+            throw new ImperativeError({ msg: "Unknown DB2 Driver Error" });
+        }
+
+        if (original instanceof ImperativeError) {
+            throw original;
+        }
+
+        const msgStr = original.message || original.error || String(original);
         const details = {
-            Error: original.message.trim(),
-            SQLCODE: original.sqlcode,
-            SQLSTATE: original.state,
+            Error: msgStr.trim(),
+            SQLCODE: original.sqlcode != null ? original.sqlcode : undefined,
+            SQLSTATE: original.state != null ? original.state : undefined,
         };
+
+        const prefix = original.error ? "DB2 ODBC Driver Error:" : "DB2 Driver Error:";
         const error: IImperativeError = {
-            msg: `DB2 ODBC Driver Error: ${original.error}\n`,
+            msg: `${prefix} ${original.error || msgStr}\n`,
             additionalDetails: TextUtils.prettyJson(details, undefined, false),
         };
         throw new ImperativeError(error);

--- a/src/api/ExecuteSQL.ts
+++ b/src/api/ExecuteSQL.ts
@@ -9,13 +9,11 @@
 *                                                                                 *
 */
 
-import * as ibmdb from "ibm_db";
 import { IDB2Session } from "../rest/session/doc/IDB2Session";
-import { ConnectionString } from "./ConnectionString";
-import { DB2Error } from "./DB2Error";
-import { DB2_PARM_INPUT, IDB2Parameter } from "./doc/IDB2Parameter";
+import { IDB2Parameter } from "./doc/IDB2Parameter";
 import { SessionValidator } from "./SessionValidator";
-import { DB2Constants } from "./DB2Constants";
+import { DB2DriverFactory } from "./driver/DB2DriverFactory";
+import { IDB2Driver } from "./driver/IDB2Driver";
 
 /**
  * Class to handle execution of SQL statements
@@ -24,21 +22,7 @@ import { DB2Constants } from "./DB2Constants";
  */
 export class ExecuteSQL {
 
-    /**
-     * Connection to a DB2 region
-     * @type {ibmdb.Database}
-     * @memberof ExportTable
-     * @private
-     */
-    private mConnection: ibmdb.Database;
-
-    /**
-     * The connection string to use with ODBC driver
-     * @type {string}
-     * @memberof ExportTable
-     * @private
-     */
-    private readonly mConnectionString: string;
+    private readonly driver: IDB2Driver;
 
     /**
      * Constructor
@@ -46,7 +30,7 @@ export class ExecuteSQL {
      */
     constructor(session: IDB2Session) {
         SessionValidator.validate(session);
-        this.mConnectionString = ConnectionString.buildFromSession(session);
+        this.driver = DB2DriverFactory.getDriver(session);
     }
 
     /**
@@ -54,35 +38,9 @@ export class ExecuteSQL {
      * @param {string} sql Statement to execute
      * @param {IDB2Parameter[]} parameters Array of DB2 parameters to bind to the SQL statement
      * @returns {IterableIterator<any>}
-     * @static
      * @memberof ExecuteSQL
      */
-    public *execute(sql: string, parameters?: IDB2Parameter[]): IterableIterator<any> {
-        const options = {
-            fetchMode: DB2Constants.FETCH_MODE_OBJECT,
-        };
-        let result;
-        const newParameters: ibmdb.SQLParam[] = [];
-        try {
-            this.mConnection = ibmdb.openSync(this.mConnectionString, options);
-            if (parameters != null) {
-                for (const parameter of parameters) {
-                    if (parameter.ParamType == undefined) { parameter.ParamType = DB2_PARM_INPUT; }
-                    newParameters.push(parameter as ibmdb.SQLParam);
-                }
-            }
-            result = this.mConnection.queryResultSync(sql, newParameters);
-            if (result instanceof Error) {
-                throw result;
-            }
-            Array.isArray(result) ? yield result[0].fetchAllSync(): yield result.fetchAllSync();
-            while (Array.isArray(result) ? result[0].moreResultsSync(): result.moreResultsSync()) {
-                Array.isArray(result) ? yield result[0].fetchAllSync(): yield result.fetchAllSync();
-            }
-            this.mConnection.closeSync();
-        }
-        catch (err) {
-            DB2Error.process(err);
-        }
+    public execute(sql: string, parameters?: IDB2Parameter[]): IterableIterator<any> {
+        return this.driver.execute(sql, parameters);
     }
 }

--- a/src/api/ExportTable.ts
+++ b/src/api/ExportTable.ts
@@ -10,14 +10,13 @@
 */
 
 import { ImperativeExpect, ImperativeError } from "@zowe/imperative";
-import * as ibmdb from "ibm_db";
 import { IDB2Session } from "../rest/session/doc/IDB2Session";
-import { ConnectionString } from "./ConnectionString";
 import { DB2Error } from "./DB2Error";
 import { IDB2Column } from "./doc/IDB2Column";
 import { noDatabaseName, noTableName } from "./doc/Messages";
 import { SessionValidator } from "./SessionValidator";
-import { DB2Constants } from "./DB2Constants";
+import { DB2DriverFactory } from "./driver/DB2DriverFactory";
+import { IDB2Driver } from "./driver/IDB2Driver";
 
 /**
  * Class to handle exporting of DB2 tables
@@ -28,43 +27,28 @@ export abstract class ExportTable {
 
     /**
      * The database name
-     * @type {string}
-     * @memberof ExportTable
-     * @private
      */
     protected readonly mDatabase: string;
 
     /**
      * The table name
-     * @type {string}
-     * @memberof ExportTable
-     * @private
      */
     protected readonly mTable: string;
 
     /**
      * The table metadata
-     * @type {IDB2Column[]|null}
-     * @memberof ExportTable
-     * @private
      */
     protected mMetadata: IDB2Column[] | null;
 
     /**
-     * Connection to a DB2 region
-     * @type {ibmdb.Database}
-     * @memberof ExportTable
-     * @private
+     * The session object
      */
-    private mConnection: ibmdb.Database;
+    protected readonly mSession: IDB2Session;
 
     /**
-     * The connection string to use with the ODBC driver
-     * @type {string}
-     * @memberof ExportTable
-     * @private
+     * Driver instance
      */
-    private readonly mConnectionString: string;
+    private readonly mDriver: IDB2Driver;
 
     /**
      * Constructor
@@ -76,52 +60,35 @@ export abstract class ExportTable {
         SessionValidator.validate(session);
         ImperativeExpect.toBeDefinedAndNonBlank(databaseName, noDatabaseName.message);
         ImperativeExpect.toBeDefinedAndNonBlank(tableName, noTableName.message);
+        this.mSession = session;
         this.mDatabase = databaseName;
         this.mTable = tableName;
-        this.mConnectionString = ConnectionString.buildFromSession(session);
+        this.mDriver = DB2DriverFactory.getDriver(session);
         this.mMetadata = null;
     }
 
     public async init() {
-        const options = {
-            fetchMode: DB2Constants.FETCH_MODE_OBJECT,
-        };
         try {
-            this.mConnection = ibmdb.openSync(this.mConnectionString, options);
+            this.mMetadata = await this.getTableMeta();
         }
         catch (err) {
             DB2Error.process(err);
         }
-        this.mMetadata = await this.getTableMeta();
         if (Array.isArray(this.mMetadata) && this.mMetadata.length === 0) {
             throw new ImperativeError({msg: `Error getting metadata for the table ${this.mDatabase}.${this.mTable}`});
         }
     }
 
     /**
-     * Get a table metadata
+     * Get table metadata
      * @returns {Promise<IDB2Column[]>}
      * @memberof ExportTable
      */
-    public getTableMeta(): Promise<IDB2Column[]> {
-        return new Promise((resolve, reject) => {
-            if (this.mMetadata == null) {
-                this.mConnection.columns(null, this.mDatabase, this.mTable, null, (err, res) => {
-                    if (err !== null) {
-                        reject(err);
-                    }
-
-                    let data: IDB2Column[] = [];
-                    if (res[0] && !(Array.isArray(res[0]))) {
-                        data = res as IDB2Column[];
-                    }
-                    resolve(data);
-                });
-            }
-            else {
-                resolve(this.mMetadata);
-            }
-        });
+    public async getTableMeta(): Promise<IDB2Column[]> {
+        if (this.mMetadata == null) {
+            this.mMetadata = await this.mDriver.getTableColumns(this.mDatabase, this.mTable);
+        }
+        return this.mMetadata;
     }
 
     public getColumnMeta(columnName: string): IDB2Column {
@@ -134,26 +101,16 @@ export abstract class ExportTable {
     }
 
     /**
-     * Supply data from table by one row
+     * Supply data from table row by row
      * @returns {IterableIterator<any>}
      */
-    public *rows(): IterableIterator<any> {
-        const columns = this.getColumnNames().join(", ");
-        const query = `SELECT ${columns} FROM ${this.mDatabase}.${this.mTable}`;
-        const result = this.mConnection.queryResultSync(query);
-        if (result instanceof Error) {
-            throw result;
-        }
-        let row = Array.isArray(result) ? result[0].fetchSync(): result.fetchSync();
-        while (row != null) {
-            yield row;
-            row = Array.isArray(result) ? result[0].fetchSync(): result.fetchSync();
-        }
-        Array.isArray(result) ? result[0].closeSync(): result.closeSync();
+    public rows(): IterableIterator<any> {
+        const columns = this.getColumnNames();
+        return this.mDriver.getTableRows(this.mDatabase, this.mTable, columns);
     }
 
     /**
-     * Extract a list of columns out of a table metadata
+     * Extract a list of columns out of table metadata
      * @returns {string[]} Columns list
      */
     public getColumnNames(): string[] {

--- a/src/api/ExportTable.ts
+++ b/src/api/ExportTable.ts
@@ -41,11 +41,6 @@ export abstract class ExportTable {
     protected mMetadata: IDB2Column[] | null;
 
     /**
-     * The session object
-     */
-    protected readonly mSession: IDB2Session;
-
-    /**
      * Driver instance
      */
     private readonly mDriver: IDB2Driver;
@@ -60,7 +55,6 @@ export abstract class ExportTable {
         SessionValidator.validate(session);
         ImperativeExpect.toBeDefinedAndNonBlank(databaseName, noDatabaseName.message);
         ImperativeExpect.toBeDefinedAndNonBlank(tableName, noTableName.message);
-        this.mSession = session;
         this.mDatabase = databaseName;
         this.mTable = tableName;
         this.mDriver = DB2DriverFactory.getDriver(session);

--- a/src/api/SessionValidator.ts
+++ b/src/api/SessionValidator.ts
@@ -41,6 +41,12 @@ export class SessionValidator {
                     msg: `Invalid driverType '${params.driverType}'. Supported values are 'odbc' or 'jdbc'.`
                 });
             }
+            if (driverLower === "jdbc" && !params.jdbcJarPath) {
+                throw new ImperativeError({
+                    msg: `jdbcJarPath is required when driverType is 'jdbc'. ` +
+                         `Specify the path to db2jcc4.jar using --jdbc-jar or in your Zowe profile.`
+                });
+            }
         }
     }
 }

--- a/src/api/SessionValidator.ts
+++ b/src/api/SessionValidator.ts
@@ -9,7 +9,7 @@
 *                                                                                 *
 */
 
-import { ImperativeExpect } from "@zowe/imperative";
+import { ImperativeExpect, ImperativeError } from "@zowe/imperative";
 import { IDB2Session } from "../";
 import { noDatabaseName, noDB2Input, noHostName, noPassword, noPortNumber, noUserName } from "./doc/Messages";
 
@@ -33,5 +33,14 @@ export class SessionValidator {
         ImperativeExpect.toBeDefinedAndNonBlank(params.user, "user", noUserName.message);
         ImperativeExpect.toBeDefinedAndNonBlank(params.password, "password", noPassword.message);
         ImperativeExpect.toBeDefinedAndNonBlank(params.database, "database", noDatabaseName.message);
+
+        if (params.driverType) {
+            const driverLower = params.driverType.toLowerCase();
+            if (driverLower !== "odbc" && driverLower !== "jdbc") {
+                throw new ImperativeError({
+                    msg: `Invalid driverType '${params.driverType}'. Supported values are 'odbc' or 'jdbc'.`
+                });
+            }
+        }
     }
 }

--- a/src/api/driver/DB2DriverFactory.ts
+++ b/src/api/driver/DB2DriverFactory.ts
@@ -1,0 +1,33 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { IDB2Session } from "../../rest/session/doc/IDB2Session";
+import { IDB2Driver } from "./IDB2Driver";
+import { JdbcDriver } from "./JdbcDriver";
+import { OdbcDriver } from "./OdbcDriver";
+
+/**
+ * Factory class to instantiate the appropriate DB2 driver (ODBC or JDBC)
+ */
+export class DB2DriverFactory {
+    /**
+     * Get a DB2 driver instance for the given session configuration
+     * @param session DB2 session parameters
+     * @returns IDB2Driver instance (OdbcDriver or JdbcDriver)
+     */
+    public static getDriver(session: IDB2Session): IDB2Driver {
+        const driverType = session.driverType ? session.driverType.toLowerCase() : "odbc";
+        if (driverType === "jdbc") {
+            return new JdbcDriver(session);
+        }
+        return new OdbcDriver(session);
+    }
+}

--- a/src/api/driver/IDB2Driver.ts
+++ b/src/api/driver/IDB2Driver.ts
@@ -25,7 +25,7 @@ export interface IDB2Driver {
     /**
      * Call a stored procedure and return procedure response
      */
-    callSP(routineName: string, parameters?: IDB2Parameter[]): Promise<IDB2Response> | IDB2Response;
+    callSP(routineName: string, parameters?: IDB2Parameter[]): IDB2Response;
 
     /**
      * Get column metadata for a database table

--- a/src/api/driver/IDB2Driver.ts
+++ b/src/api/driver/IDB2Driver.ts
@@ -1,0 +1,39 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { IDB2Column } from "../doc/IDB2Column";
+import { IDB2Parameter } from "../doc/IDB2Parameter";
+import { IDB2Response } from "../doc/IDB2Response";
+
+/**
+ * Interface defining the operations supported by Db2 drivers (ODBC / JDBC)
+ */
+export interface IDB2Driver {
+    /**
+     * Execute SQL query statement and return array of result rows / sets
+     */
+    execute(sql: string, parameters?: IDB2Parameter[]): IterableIterator<any>;
+
+    /**
+     * Call a stored procedure and return procedure response
+     */
+    callSP(routineName: string, parameters?: IDB2Parameter[]): Promise<IDB2Response> | IDB2Response;
+
+    /**
+     * Get column metadata for a database table
+     */
+    getTableColumns(database: string, table: string): Promise<IDB2Column[]>;
+
+    /**
+     * Get table rows for specific columns
+     */
+    getTableRows(database: string, table: string, columns: string[]): IterableIterator<any>;
+}

--- a/src/api/driver/JdbcDriver.ts
+++ b/src/api/driver/JdbcDriver.ts
@@ -21,7 +21,9 @@ import { IDB2Session } from "../../rest/session/doc/IDB2Session";
 import { IDB2Driver } from "./IDB2Driver";
 
 /**
- * JDBC driver implementation executing queries via a Java runner subprocess
+ * JDBC driver implementation executing queries via a Java runner subprocess.
+ * Credentials are passed via stdin (never as process arguments) to prevent
+ * them from appearing in ps/proc listings.
  */
 export class JdbcDriver implements IDB2Driver {
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
@@ -58,7 +60,8 @@ export class JdbcDriver implements IDB2Driver {
     }
 
     /**
-     * Build the classpath string including JDBC driver JAR, license JAR, and runner class directory
+     * Build the classpath string including JDBC driver JAR, license JAR, and runner class directory.
+     * Only adds src/java as a fallback if the compiled class is absent from lib/java.
      */
     public buildClasspath(): string {
         const paths: string[] = [];
@@ -71,46 +74,58 @@ export class JdbcDriver implements IDB2Driver {
             paths.push(...this.resolveClasspathEntry(this.session.jdbcLicensePath));
         }
 
-        // Add runner directory (both lib/java and src/java locations)
+        // Prefer the compiled class in lib/java; only fall back to src/java if not compiled yet
         const runnerLibDir = path.resolve(__dirname, "../../java");
         const runnerSrcDir = path.resolve(__dirname, "../../../src/java");
-        if (fs.existsSync(runnerLibDir)) {
+        const javaClassFile = path.join(runnerLibDir, "Db2JdbcRunner.class");
+
+        if (fs.existsSync(javaClassFile)) {
             paths.push(runnerLibDir);
-        }
-        if (fs.existsSync(runnerSrcDir)) {
+        } else if (fs.existsSync(runnerSrcDir)) {
             paths.push(runnerSrcDir);
+        } else if (fs.existsSync(runnerLibDir)) {
+            paths.push(runnerLibDir);
         }
 
         return paths.join(path.delimiter);
     }
 
     /**
-     * Invoke the Java Db2JdbcRunner subprocess
+     * Invoke the Java Db2JdbcRunner subprocess.
+     * Credentials and action-specific args are written to the process stdin as a JSON line
+     * so they are never visible in ps/proc listings.
      */
-    public runJavaCommand(action: string, extraArgs: string[] = []): any {
+    private runJavaCommand(action: string, extraArgs: string[] = []): any {
         const javaExe = this.session.javaPath || "java";
         const classpath = this.buildClasspath();
 
-        const runnerDir = path.resolve(__dirname, "../../java");
-        const javaSourceFile = path.join(runnerDir, "Db2JdbcRunner.java");
-        const javaClassFile = path.join(runnerDir, "Db2JdbcRunner.class");
+        const runnerLibDir = path.resolve(__dirname, "../../java");
+        const javaSourceFile = path.join(runnerLibDir, "Db2JdbcRunner.java");
+        const javaClassFile = path.join(runnerLibDir, "Db2JdbcRunner.class");
 
         const args: string[] = ["-cp", classpath];
 
-        // If Java class file doesn't exist, try running single-file Java source (Java 11+)
+        // If compiled class is absent, use single-file Java source launcher (Java 11+)
         if (!fs.existsSync(javaClassFile) && fs.existsSync(javaSourceFile)) {
             args.push(javaSourceFile);
         } else {
             args.push("Db2JdbcRunner");
         }
 
-        args.push(action, this.jdbcUrl, this.session.user || "", this.session.password || "");
-        args.push(...extraArgs);
+        args.push(action, this.jdbcUrl);
+
+        // Build the stdin envelope — credentials and action args never touch the process arg list
+        const stdinPayload = JSON.stringify({
+            user:     this.session.user     || "",
+            password: this.session.password || "",
+            args:     extraArgs,
+        });
 
         try {
             const output = child_process.execFileSync(javaExe, args, {
                 encoding: "utf-8",
                 maxBuffer: JdbcDriver.MAX_BUFFER_SIZE,
+                input:     stdinPayload,
             });
             return JSON.parse(output.trim());
         } catch (err: any) {
@@ -145,11 +160,6 @@ export class JdbcDriver implements IDB2Driver {
             return response as IDB2Response;
         } catch (err) {
             DB2Error.process(err);
-            return {
-                success: false,
-                results: [],
-                failureResponse: err.message,
-            };
         }
     }
 

--- a/src/api/driver/JdbcDriver.ts
+++ b/src/api/driver/JdbcDriver.ts
@@ -1,0 +1,160 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import * as child_process from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import { ConnectionString } from "../ConnectionString";
+import { DB2Error } from "../DB2Error";
+import { IDB2Column } from "../doc/IDB2Column";
+import { IDB2Parameter } from "../doc/IDB2Parameter";
+import { IDB2Response } from "../doc/IDB2Response";
+import { IDB2Session } from "../../rest/session/doc/IDB2Session";
+import { IDB2Driver } from "./IDB2Driver";
+
+/**
+ * JDBC driver implementation executing queries via a Java runner subprocess
+ */
+export class JdbcDriver implements IDB2Driver {
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+    private static readonly MAX_BUFFER_SIZE = 50 * 1024 * 1024;
+    private readonly session: IDB2Session;
+    private readonly jdbcUrl: string;
+
+    constructor(session: IDB2Session) {
+        this.session = session;
+        this.jdbcUrl = ConnectionString.buildJdbcUrlFromSession(session);
+    }
+
+    /**
+     * Build the classpath string including JDBC driver JAR, license JAR, and runner class directory
+     */
+    public buildClasspath(): string {
+        const paths: string[] = [];
+
+        if (this.session.jdbcJarPath) {
+            paths.push(this.session.jdbcJarPath);
+        }
+
+        if (this.session.jdbcLicensePath) {
+            paths.push(this.session.jdbcLicensePath);
+        }
+
+        // Add runner directory (both lib/java and src/java locations)
+        const runnerLibDir = path.resolve(__dirname, "../../java");
+        const runnerSrcDir = path.resolve(__dirname, "../../../src/java");
+        if (fs.existsSync(runnerLibDir)) {
+            paths.push(runnerLibDir);
+        }
+        if (fs.existsSync(runnerSrcDir)) {
+            paths.push(runnerSrcDir);
+        }
+
+        return paths.join(path.delimiter);
+    }
+
+    /**
+     * Invoke the Java Db2JdbcRunner subprocess
+     */
+    public runJavaCommand(action: string, extraArgs: string[] = []): any {
+        const javaExe = this.session.javaPath || "java";
+        const classpath = this.buildClasspath();
+
+        const runnerDir = path.resolve(__dirname, "../../java");
+        const javaSourceFile = path.join(runnerDir, "Db2JdbcRunner.java");
+        const javaClassFile = path.join(runnerDir, "Db2JdbcRunner.class");
+
+        const args: string[] = ["-cp", classpath];
+
+        // If Java class file doesn't exist, try running single-file Java source (Java 11+)
+        if (!fs.existsSync(javaClassFile) && fs.existsSync(javaSourceFile)) {
+            args.push(javaSourceFile);
+        } else {
+            args.push("Db2JdbcRunner");
+        }
+
+        args.push(action, this.jdbcUrl, this.session.user || "", this.session.password || "");
+        args.push(...extraArgs);
+
+        try {
+            const output = child_process.execFileSync(javaExe, args, {
+                encoding: "utf-8",
+                maxBuffer: JdbcDriver.MAX_BUFFER_SIZE,
+            });
+            return JSON.parse(output.trim());
+        } catch (err: any) {
+            const errorMsg = err.stderr ? err.stderr.toString() : err.message;
+            throw new Error(`JDBC Driver execution failed: ${errorMsg}`);
+        }
+    }
+
+    public *execute(sql: string, parameters?: IDB2Parameter[]): IterableIterator<any> {
+        try {
+            const extraArgs: string[] = [sql];
+            if (parameters && parameters.length > 0) {
+                extraArgs.push(JSON.stringify(parameters));
+            }
+            const results = this.runJavaCommand("execute", extraArgs);
+            if (Array.isArray(results)) {
+                for (const resultSet of results) {
+                    yield resultSet;
+                }
+            } else {
+                yield results;
+            }
+        } catch (err) {
+            DB2Error.process(err);
+        }
+    }
+
+    public callSP(routineName: string, parameters?: IDB2Parameter[]): IDB2Response {
+        try {
+            const paramsJson = JSON.stringify(parameters || []);
+            const response = this.runJavaCommand("call", [routineName, paramsJson]);
+            return response as IDB2Response;
+        } catch (err) {
+            DB2Error.process(err);
+            return {
+                success: false,
+                results: [],
+                failureResponse: err.message,
+            };
+        }
+    }
+
+    public async getTableColumns(database: string, table: string): Promise<IDB2Column[]> {
+        try {
+            const columns = this.runJavaCommand("getColumns", [database, table]);
+            return columns as IDB2Column[];
+        } catch (err) {
+            DB2Error.process(err);
+            return [];
+        }
+    }
+
+    public *getTableRows(database: string, table: string, columns: string[]): IterableIterator<any> {
+        const colString = columns.join(", ");
+        const query = `SELECT ${colString} FROM ${database}.${table}`;
+        try {
+            const results = this.runJavaCommand("execute", [query]);
+            if (Array.isArray(results) && results.length > 0) {
+                const rows = results[0];
+                if (Array.isArray(rows)) {
+                    for (const row of rows) {
+                        yield row;
+                    }
+                }
+            }
+        } catch (err) {
+            DB2Error.process(err);
+        }
+    }
+}

--- a/src/api/driver/JdbcDriver.ts
+++ b/src/api/driver/JdbcDriver.ts
@@ -35,17 +35,40 @@ export class JdbcDriver implements IDB2Driver {
     }
 
     /**
+     * Resolve a classpath entry path. If a directory is provided, locate all .jar files or use wildcard.
+     */
+    private resolveClasspathEntry(entryPath: string): string[] {
+        if (!fs.existsSync(entryPath)) {
+            return [entryPath];
+        }
+        const stat = fs.statSync(entryPath);
+        if (stat.isDirectory()) {
+            try {
+                const files = fs.readdirSync(entryPath);
+                const jars = files.filter(f => f.toLowerCase().endsWith(".jar")).map(f => path.join(entryPath, f));
+                if (jars.length > 0) {
+                    return jars;
+                }
+            } catch (e) {
+                // Fallback to directory wildcard
+            }
+            return [path.join(entryPath, "*")];
+        }
+        return [entryPath];
+    }
+
+    /**
      * Build the classpath string including JDBC driver JAR, license JAR, and runner class directory
      */
     public buildClasspath(): string {
         const paths: string[] = [];
 
         if (this.session.jdbcJarPath) {
-            paths.push(this.session.jdbcJarPath);
+            paths.push(...this.resolveClasspathEntry(this.session.jdbcJarPath));
         }
 
         if (this.session.jdbcLicensePath) {
-            paths.push(this.session.jdbcLicensePath);
+            paths.push(...this.resolveClasspathEntry(this.session.jdbcLicensePath));
         }
 
         // Add runner directory (both lib/java and src/java locations)

--- a/src/api/driver/OdbcDriver.ts
+++ b/src/api/driver/OdbcDriver.ts
@@ -1,0 +1,162 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import * as ibmdb from "ibm_db";
+import { ConnectionString } from "../ConnectionString";
+import { DB2Constants } from "../DB2Constants";
+import { DB2Error } from "../DB2Error";
+import { IDB2Column } from "../doc/IDB2Column";
+import { DB2_PARM_INOUT, DB2_PARM_INPUT, DB2_PARM_OUTPUT, IDB2Parameter } from "../doc/IDB2Parameter";
+import { IDB2Response } from "../doc/IDB2Response";
+import { IDB2Session } from "../../rest/session/doc/IDB2Session";
+import { IDB2Driver } from "./IDB2Driver";
+
+/**
+ * ODBC driver implementation using node-ibm_db
+ */
+export class OdbcDriver implements IDB2Driver {
+    private readonly session: IDB2Session;
+    private readonly connectionString: string;
+
+    constructor(session: IDB2Session) {
+        this.session = session;
+        this.connectionString = ConnectionString.buildFromSession(session);
+    }
+
+    public *execute(sql: string, parameters?: IDB2Parameter[]): IterableIterator<any> {
+        const options = {
+            fetchMode: DB2Constants.FETCH_MODE_OBJECT,
+        };
+        let result;
+        const newParameters: ibmdb.SQLParam[] = [];
+        try {
+            const connection = ibmdb.openSync(this.connectionString, options);
+            if (parameters != null) {
+                for (const parameter of parameters) {
+                    if (parameter.ParamType == undefined) { parameter.ParamType = DB2_PARM_INPUT; }
+                    newParameters.push(parameter as ibmdb.SQLParam);
+                }
+            }
+            result = connection.queryResultSync(sql, newParameters);
+            if (result instanceof Error) {
+                throw result;
+            }
+            Array.isArray(result) ? yield result[0].fetchAllSync() : yield result.fetchAllSync();
+            while (Array.isArray(result) ? result[0].moreResultsSync() : result.moreResultsSync()) {
+                Array.isArray(result) ? yield result[0].fetchAllSync() : yield result.fetchAllSync();
+            }
+            connection.closeSync();
+        } catch (err) {
+            DB2Error.process(err);
+        }
+    }
+
+    public callSP(routineName: string, parameters?: IDB2Parameter[]): IDB2Response {
+        const options = {
+            fetchMode: DB2Constants.FETCH_MODE_ARRAY,
+        };
+        const response: IDB2Response = {
+            success: false,
+            results: [],
+            failureResponse: undefined,
+        };
+        const query: string = `CALL ${routineName}`;
+        let result: any;
+        let outVarCount: number = 0;
+        const newParameters: ibmdb.SQLParam[] = [];
+
+        if (parameters != null) {
+            for (const parameter of parameters) {
+                if (parameter.ParamType === DB2_PARM_INOUT || parameter.ParamType === DB2_PARM_OUTPUT) {
+                    outVarCount++;
+                }
+                if (parameter.ParamType == undefined) { parameter.ParamType = DB2_PARM_INPUT; }
+                newParameters.push(parameter as ibmdb.SQLParam);
+            }
+        }
+
+        try {
+            const db2 = ibmdb.openSync(this.connectionString, options);
+            const preparedStatement = db2.prepareSync(query);
+            result = preparedStatement.executeSync(newParameters);
+
+            if (outVarCount !== 0 && Array.isArray(result)) {
+                while (outVarCount > 0) {
+                    response.results.push(result[1].shift());
+                    outVarCount--;
+                }
+                result = result[0];
+            }
+            const data = result.fetchAllSync();
+            if (data.length) {
+                response.results.push(data);
+            }
+            while (result.moreResultsSync()) {
+                response.results.push(result.fetchAllSync());
+            }
+            response.success = true;
+            result.closeSync();
+            db2.closeSync();
+        } catch (err) {
+            DB2Error.process(err);
+        }
+        return response;
+    }
+
+    public getTableColumns(database: string, table: string): Promise<IDB2Column[]> {
+        return new Promise((resolve, reject) => {
+            const options = {
+                fetchMode: DB2Constants.FETCH_MODE_OBJECT,
+            };
+            try {
+                const connection = ibmdb.openSync(this.connectionString, options);
+                connection.columns(null, database, table, null, (err, res) => {
+                    connection.closeSync();
+                    if (err !== null) {
+                        reject(err);
+                        return;
+                    }
+                    let data: IDB2Column[] = [];
+                    if (res[0] && !(Array.isArray(res[0]))) {
+                        data = res as IDB2Column[];
+                    }
+                    resolve(data);
+                });
+            } catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    public *getTableRows(database: string, table: string, columns: string[]): IterableIterator<any> {
+        const options = {
+            fetchMode: DB2Constants.FETCH_MODE_OBJECT,
+        };
+        const colString = columns.join(", ");
+        const query = `SELECT ${colString} FROM ${database}.${table}`;
+        try {
+            const connection = ibmdb.openSync(this.connectionString, options);
+            const result = connection.queryResultSync(query);
+            if (result instanceof Error) {
+                throw result;
+            }
+            let row = Array.isArray(result) ? result[0].fetchSync() : result.fetchSync();
+            while (row != null) {
+                yield row;
+                row = Array.isArray(result) ? result[0].fetchSync() : result.fetchSync();
+            }
+            Array.isArray(result) ? result[0].closeSync() : result.closeSync();
+            connection.closeSync();
+        } catch (err) {
+            DB2Error.process(err);
+        }
+    }
+}

--- a/src/cli/DB2Session.ts
+++ b/src/cli/DB2Session.ts
@@ -142,7 +142,8 @@ export class DB2Session {
     public static DB2_OPTION_JDBC_PROPERTIES: ICommandOptionDefinition = {
         name: "jdbcProperties",
         aliases: ["jdbc-props"],
-        description: "Additional JDBC connection properties (e.g. 'securityMechanism=13;clientProgramName=ZoweCLI;')",
+        description: "Additional JDBC connection properties (e.g. 'clientProgramName=ZoweCLI;'). " +
+            "Security-sensitive keys (user, password, sslConnection, securityMechanism) are not permitted.",
         type: "string",
         group: DB2Session.DB2_CONNECTION_OPTION_GROUP
     };

--- a/src/cli/DB2Session.ts
+++ b/src/cli/DB2Session.ts
@@ -88,6 +88,66 @@ export class DB2Session {
     };
 
     /**
+     * Option used in profile creation and commands to specify driver type ("odbc" or "jdbc")
+     */
+    public static DB2_OPTION_DRIVER_TYPE: ICommandOptionDefinition = {
+        name: "driverType",
+        aliases: ["driver"],
+        description: "Driver type used to connect to Db2: 'odbc' or 'jdbc'",
+        type: "string",
+        allowableValues: {
+            values: ["odbc", "jdbc"],
+            caseSensitive: false
+        },
+        defaultValue: "odbc",
+        group: DB2Session.DB2_CONNECTION_OPTION_GROUP
+    };
+
+    /**
+     * Option used in profile creation and commands to specify path to Db2 JDBC driver JAR file
+     */
+    public static DB2_OPTION_JDBC_JAR: ICommandOptionDefinition = {
+        name: "jdbcJarPath",
+        aliases: ["jdbc-jar"],
+        description: "Path to the Db2 JDBC driver JAR file (e.g. db2jcc4.jar) or directory containing it",
+        type: "string",
+        group: DB2Session.DB2_CONNECTION_OPTION_GROUP
+    };
+
+    /**
+     * Option used in profile creation and commands to specify path to Db2 JDBC license JAR file
+     */
+    public static DB2_OPTION_JDBC_LICENSE: ICommandOptionDefinition = {
+        name: "jdbcLicensePath",
+        aliases: ["jdbc-license"],
+        description: "Path to the Db2 JDBC license JAR file (e.g. db2jcc_license_cisuz.jar) or directory containing it",
+        type: "string",
+        group: DB2Session.DB2_CONNECTION_OPTION_GROUP
+    };
+
+    /**
+     * Option used in profile creation and commands to specify Java executable path for JDBC
+     */
+    public static DB2_OPTION_JAVA_PATH: ICommandOptionDefinition = {
+        name: "javaPath",
+        aliases: ["java-path"],
+        description: "Path to Java executable to use for JDBC connections (defaults to 'java')",
+        type: "string",
+        group: DB2Session.DB2_CONNECTION_OPTION_GROUP
+    };
+
+    /**
+     * Option used in profile creation and commands to specify additional JDBC connection properties
+     */
+    public static DB2_OPTION_JDBC_PROPERTIES: ICommandOptionDefinition = {
+        name: "jdbcProperties",
+        aliases: ["jdbc-props"],
+        description: "Additional JDBC connection properties (e.g. 'securityMechanism=13;clientProgramName=ZoweCLI;')",
+        type: "string",
+        group: DB2Session.DB2_CONNECTION_OPTION_GROUP
+    };
+
+    /**
      * Options related to connecting to DB2
      * These options can be filled in if the user creates a profile
      */
@@ -97,7 +157,12 @@ export class DB2Session {
         DB2Session.DB2_OPTION_USER,
         DB2Session.DB2_OPTION_PASS,
         DB2Session.DB2_OPTION_DATABASE,
-        DB2Session.DB2_OPTION_SSL_FILE
+        DB2Session.DB2_OPTION_SSL_FILE,
+        DB2Session.DB2_OPTION_DRIVER_TYPE,
+        DB2Session.DB2_OPTION_JDBC_JAR,
+        DB2Session.DB2_OPTION_JDBC_LICENSE,
+        DB2Session.DB2_OPTION_JAVA_PATH,
+        DB2Session.DB2_OPTION_JDBC_PROPERTIES
     ];
 
     /**
@@ -115,6 +180,11 @@ export class DB2Session {
             password: args.password,
             database: args.database,
             sslFile: args.sslFile,
+            driverType: args.driverType ? (args.driverType.toLowerCase() as "odbc" | "jdbc") : "odbc",
+            jdbcJarPath: args.jdbcJarPath,
+            jdbcLicensePath: args.jdbcLicensePath,
+            javaPath: args.javaPath,
+            jdbcProperties: args.jdbcProperties,
         };
         return new Session(DB2session);
     }
@@ -135,6 +205,11 @@ export class DB2Session {
             password: args.password,
             database: args.database,
             sslFile: args.sslFile,
+            driverType: args.driverType ? (args.driverType.toLowerCase() as "odbc" | "jdbc") : "odbc",
+            jdbcJarPath: args.jdbcJarPath,
+            jdbcLicensePath: args.jdbcLicensePath,
+            javaPath: args.javaPath,
+            jdbcProperties: args.jdbcProperties,
         };
 
         const sessCfgWithCreds = await ConnectionPropsForSessCfg.addPropsOrPrompt<IDB2Session>(sessCfg, args, {doPrompting, parms: handlerParams});

--- a/src/imperative.ts
+++ b/src/imperative.ts
@@ -83,6 +83,48 @@ const config: IImperativeConfig = {
                             type: "string",
                         },
                     },
+                    driverType: {
+                        type: "string",
+                        optionDefinition: {
+                            name: "driver-type",
+                            aliases: ["driver"],
+                            description: "Driver type used to connect to Db2: 'odbc' or 'jdbc'",
+                            type: "string",
+                        },
+                    },
+                    jdbcJarPath: {
+                        type: "string",
+                        optionDefinition: {
+                            name: "jdbc-jar",
+                            description: "Path to the Db2 JDBC driver JAR file (e.g. db2jcc4.jar) or directory containing it",
+                            type: "string",
+                        },
+                    },
+                    jdbcLicensePath: {
+                        type: "string",
+                        optionDefinition: {
+                            name: "jdbc-license",
+                            description: "Path to the Db2 JDBC license JAR file (e.g. db2jcc_license_cisuz.jar) or directory containing it",
+                            type: "string",
+                        },
+                    },
+                    javaPath: {
+                        type: "string",
+                        optionDefinition: {
+                            name: "java-path",
+                            description: "Path to Java executable to use for JDBC connections",
+                            type: "string",
+                        },
+                    },
+                    jdbcProperties: {
+                        type: "string",
+                        optionDefinition: {
+                            name: "jdbc-props",
+                            aliases: ["jdbc-properties"],
+                            description: "Additional JDBC connection properties",
+                            type: "string",
+                        },
+                    },
                 },
             },
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,3 +25,7 @@ export * from "./api/ExportTable";
 export * from "./api/ExportTableSQL";
 export * from "./api/CallSP";
 export * from "./api/DB2Error";
+export * from "./api/driver/IDB2Driver";
+export * from "./api/driver/OdbcDriver";
+export * from "./api/driver/JdbcDriver";
+export * from "./api/driver/DB2DriverFactory";

--- a/src/java/Db2JdbcRunner.java
+++ b/src/java/Db2JdbcRunner.java
@@ -1,0 +1,309 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Command-line Java runner for executing Db2 JDBC queries, stored procedures, and metadata queries.
+ * Outputs JSON results to stdout.
+ */
+public class Db2JdbcRunner {
+
+    public static void main(String[] args) {
+        if (args.length < 4) {
+            System.err.println("Usage: java Db2JdbcRunner <action> <url> <user> <password> [args...]");
+            System.exit(1);
+        }
+
+        String action = args[0];
+        String url = args[1];
+        String user = args[2];
+        String password = args[3];
+
+        try {
+            // Register DB2 JDBC driver
+            try {
+                Class.forName("com.ibm.db2.jcc.DB2Driver");
+            } catch (ClassNotFoundException e) {
+                // Fallback driver name if needed
+                Class.forName("com.ibm.db2.jdbc.app.DB2Driver");
+            }
+
+            try (Connection conn = DriverManager.getConnection(url, user, password)) {
+                switch (action.toLowerCase()) {
+                    case "execute":
+                        if (args.length < 5) {
+                            throw new IllegalArgumentException("SQL query required for execute action");
+                        }
+                        executeSql(conn, args[4]);
+                        break;
+
+                    case "call":
+                        if (args.length < 5) {
+                            throw new IllegalArgumentException("Routine name required for call action");
+                        }
+                        String routineName = args[4];
+                        String paramsJson = args.length > 5 ? args[5] : "[]";
+                        callProcedure(conn, routineName, paramsJson);
+                        break;
+
+                    case "getcolumns":
+                        if (args.length < 6) {
+                            throw new IllegalArgumentException("Schema and Table required for getColumns action");
+                        }
+                        getColumns(conn, args[4], args[5]);
+                        break;
+
+                    default:
+                        throw new IllegalArgumentException("Unknown action: " + action);
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("JDBC Error: " + e.getMessage());
+            e.printStackTrace(System.err);
+            System.exit(2);
+        }
+    }
+
+    private static void executeSql(Connection conn, String sql) throws Exception {
+        List<List<Map<String, Object>>> allResults = new ArrayList<>();
+        try (Statement stmt = conn.createStatement()) {
+            boolean isResultSet = stmt.execute(sql);
+            while (true) {
+                if (isResultSet) {
+                    try (ResultSet rs = stmt.getResultSet()) {
+                        allResults.add(resultSetToListOfMaps(rs));
+                    }
+                }
+                isResultSet = stmt.getMoreResults();
+                if (!isResultSet && stmt.getUpdateCount() == -1) {
+                    break;
+                }
+            }
+        }
+        System.out.println(toJson(allResults));
+    }
+
+    private static void callProcedure(Connection conn, String routineName, String paramsJson) throws Exception {
+        // Simple call procedure runner
+        List<Object> paramList = parseSimpleJsonArray(paramsJson);
+        StringBuilder callSql = new StringBuilder("CALL ").append(routineName);
+        if (!paramList.isEmpty()) {
+            callSql.append("(");
+            for (int i = 0; i < paramList.size(); i++) {
+                callSql.append(i > 0 ? ", ?" : "?");
+            }
+            callSql.append(")");
+        }
+
+        Map<String, Object> response = new HashMap<>();
+        List<Object> results = new ArrayList<>();
+
+        try (CallableStatement cstmt = conn.prepareCall(callSql.toString())) {
+            int outCount = 0;
+            for (int i = 0; i < paramList.size(); i++) {
+                Object p = paramList.get(i);
+                int paramType = 1; // Default INPUT
+                Object data = p;
+
+                if (p instanceof Map) {
+                    Map<?, ?> pMap = (Map<?, ?>) p;
+                    if (pMap.containsKey("ParamType")) {
+                        paramType = ((Number) pMap.get("ParamType")).intValue();
+                    }
+                    data = pMap.get("Data");
+                }
+
+                int paramIndex = i + 1;
+                if (paramType == 1) { // INPUT
+                    cstmt.setObject(paramIndex, data);
+                } else if (paramType == 2) { // OUTPUT
+                    cstmt.registerOutParameter(paramIndex, Types.VARCHAR);
+                    outCount++;
+                } else if (paramType == 3) { // INOUT
+                    cstmt.setObject(paramIndex, data);
+                    cstmt.registerOutParameter(paramIndex, Types.VARCHAR);
+                    outCount++;
+                }
+            }
+
+            boolean isResultSet = cstmt.execute();
+
+            // Collect OUT parameters
+            for (int i = 0; i < paramList.size(); i++) {
+                Object p = paramList.get(i);
+                int paramType = 1;
+                if (p instanceof Map) {
+                    Map<?, ?> pMap = (Map<?, ?>) p;
+                    if (pMap.containsKey("ParamType")) {
+                        paramType = ((Number) pMap.get("ParamType")).intValue();
+                    }
+                }
+                if (paramType == 2 || paramType == 3) {
+                    results.add(cstmt.getObject(i + 1));
+                }
+            }
+
+            // Collect ResultSets
+            while (true) {
+                if (isResultSet) {
+                    try (ResultSet rs = cstmt.getResultSet()) {
+                        results.add(resultSetToListOfMaps(rs));
+                    }
+                }
+                isResultSet = cstmt.getMoreResults();
+                if (!isResultSet && cstmt.getUpdateCount() == -1) {
+                    break;
+                }
+            }
+
+            response.put("success", true);
+            response.put("results", results);
+        } catch (Exception e) {
+            response.put("success", false);
+            response.put("results", results);
+            response.put("failureResponse", e.getMessage());
+        }
+
+        System.out.println(toJson(response));
+    }
+
+    private static void getColumns(Connection conn, String schema, String table) throws Exception {
+        DatabaseMetaData meta = conn.getMetaData();
+        List<Map<String, Object>> columns = new ArrayList<>();
+        try (ResultSet rs = meta.getColumns(null, schema, table, null)) {
+            while (rs.next()) {
+                Map<String, Object> col = new HashMap<>();
+                col.put("TABLE_CAT", rs.getString("TABLE_CAT"));
+                col.put("TABLE_SCHEM", rs.getString("TABLE_SCHEM"));
+                col.put("TABLE_NAME", rs.getString("TABLE_NAME"));
+                col.put("COLUMN_NAME", rs.getString("COLUMN_NAME"));
+                col.put("DATA_TYPE", rs.getInt("DATA_TYPE"));
+                col.put("TYPE_NAME", rs.getString("TYPE_NAME"));
+                col.put("COLUMN_SIZE", rs.getInt("COLUMN_SIZE"));
+                col.put("BUFFER_LENGTH", rs.getInt("BUFFER_LENGTH"));
+                col.put("DECIMAL_DIGITS", rs.getInt("DECIMAL_DIGITS"));
+                col.put("NUM_PREC_RADIX", rs.getInt("NUM_PREC_RADIX"));
+                col.put("NULLABLE", rs.getInt("NULLABLE"));
+                col.put("REMARKS", rs.getString("REMARKS"));
+                col.put("COLUMN_DEF", rs.getString("COLUMN_DEF"));
+                col.put("SQL_DATA_TYPE", rs.getInt("SQL_DATA_TYPE"));
+                col.put("SQL_DATETIME_SUB", rs.getInt("SQL_DATETIME_SUB"));
+                col.put("CHAR_OCTET_LENGTH", rs.getInt("CHAR_OCTET_LENGTH"));
+                col.put("ORDINAL_POSITION", rs.getInt("ORDINAL_POSITION"));
+                col.put("IS_NULLABLE", rs.getString("IS_NULLABLE"));
+                columns.add(col);
+            }
+        }
+        System.out.println(toJson(columns));
+    }
+
+    private static List<Map<String, Object>> resultSetToListOfMaps(ResultSet rs) throws Exception {
+        List<Map<String, Object>> list = new ArrayList<>();
+        ResultSetMetaData meta = rs.getMetaData();
+        int colCount = meta.getColumnCount();
+        while (rs.next()) {
+            Map<String, Object> row = new HashMap<>();
+            for (int i = 1; i <= colCount; i++) {
+                String colName = meta.getColumnLabel(i);
+                Object val = rs.getObject(i);
+                row.put(colName, val);
+            }
+            list.add(row);
+        }
+        return list;
+    }
+
+    private static String toJson(Object obj) {
+        if (obj == null) return "null";
+        if (obj instanceof String) {
+            return "\"" + escapeJson((String) obj) + "\"";
+        }
+        if (obj instanceof Number || obj instanceof Boolean) {
+            return obj.toString();
+        }
+        if (obj instanceof List) {
+            StringBuilder sb = new StringBuilder("[");
+            List<?> list = (List<?>) obj;
+            for (int i = 0; i < list.size(); i++) {
+                if (i > 0) sb.append(",");
+                sb.append(toJson(list.get(i)));
+            }
+            sb.append("]");
+            return sb.toString();
+        }
+        if (obj instanceof Map) {
+            StringBuilder sb = new StringBuilder("{");
+            Map<?, ?> map = (Map<?, ?>) obj;
+            boolean first = true;
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                if (!first) sb.append(",");
+                sb.append("\"").append(escapeJson(String.valueOf(entry.getKey()))).append("\":");
+                sb.append(toJson(entry.getValue()));
+                first = false;
+            }
+            sb.append("}");
+            return sb.toString();
+        }
+        return "\"" + escapeJson(obj.toString()) + "\"";
+    }
+
+    private static String escapeJson(String s) {
+        if (s == null) return "";
+        return s.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\b", "\\b")
+                .replace("\f", "\\f")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t");
+    }
+
+    private static List<Object> parseSimpleJsonArray(String json) {
+        List<Object> list = new ArrayList<>();
+        if (json == null || json.trim().isEmpty() || json.equals("[]")) {
+            return list;
+        }
+        String trimmed = json.trim();
+        if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+            trimmed = trimmed.substring(1, trimmed.length() - 1).trim();
+            if (!trimmed.isEmpty()) {
+                String[] parts = trimmed.split(",");
+                for (String part : parts) {
+                    part = part.trim();
+                    if (part.startsWith("\"") && part.endsWith("\"")) {
+                        list.add(part.substring(1, part.length() - 1));
+                    } else if ("true".equalsIgnoreCase(part) || "false".equalsIgnoreCase(part)) {
+                        list.add(Boolean.parseBoolean(part));
+                    } else {
+                        try {
+                            list.add(Integer.parseInt(part));
+                        } catch (NumberFormatException e) {
+                            list.add(part);
+                        }
+                    }
+                }
+            }
+        }
+        return list;
+    }
+}

--- a/src/java/Db2JdbcRunner.java
+++ b/src/java/Db2JdbcRunner.java
@@ -9,6 +9,8 @@
 *                                                                                 *
 */
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -24,23 +26,66 @@ import java.util.Map;
 
 /**
  * Command-line Java runner for executing Db2 JDBC queries, stored procedures, and metadata queries.
- * Outputs JSON results to stdout.
+ *
+ * Protocol: accepts two CLI args (action, url) and reads a single JSON line from stdin containing
+ * { "user": "...", "password": "...", "args": [...] }. Credentials are never passed as process
+ * arguments so they are not visible in ps/proc listings. Outputs JSON results to stdout.
+ *
+ * The "args" array contains action-specific string arguments:
+ *   execute  : args[0] = SQL, args[1] (optional) = JSON array of parameters
+ *   call     : args[0] = routineName, args[1] (optional) = JSON array of parameters
+ *   getcolumns: args[0] = schema, args[1] = table
  */
 public class Db2JdbcRunner {
 
     public static void main(String[] args) {
-        if (args.length < 4) {
-            System.err.println("Usage: java Db2JdbcRunner <action> <url> <user> <password> [args...]");
+        if (args.length < 2) {
+            System.err.println("Usage: java Db2JdbcRunner <action> <url>");
+            System.err.println("Credentials and action args are read as JSON from stdin.");
             System.exit(1);
         }
 
         String action = args[0];
-        String url = args[1];
-        String user = args[2];
-        String password = args[3];
+        String url    = args[1];
+
+        // Read the single JSON credential+args line from stdin
+        String stdinLine;
+        try {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(System.in, "UTF-8"));
+            stdinLine = reader.readLine();
+        } catch (Exception e) {
+            System.err.println("JDBC Error: failed to read stdin: " + e.getMessage());
+            System.exit(1);
+            return;
+        }
+
+        if (stdinLine == null || stdinLine.trim().isEmpty()) {
+            System.err.println("JDBC Error: no credential JSON received on stdin");
+            System.exit(1);
+            return;
+        }
+
+        // Parse the credential envelope: {"user":"...","password":"...","args":[...]}
+        String user, password;
+        List<String> actionArgs;
+        try {
+            Map<String, Object> envelope = parseJsonObject(stdinLine.trim());
+            user     = (String) envelope.getOrDefault("user", "");
+            password = (String) envelope.getOrDefault("password", "");
+            Object rawArgs = envelope.get("args");
+            actionArgs = new ArrayList<>();
+            if (rawArgs instanceof List) {
+                for (Object a : (List<?>) rawArgs) {
+                    actionArgs.add(a == null ? "" : a.toString());
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("JDBC Error: failed to parse stdin JSON: " + e.getMessage());
+            System.exit(1);
+            return;
+        }
 
         try {
-            // Register DB2 JDBC driver (com.ibm.db2.jcc.DB2Driver)
             try {
                 Class.forName("com.ibm.db2.jcc.DB2Driver");
             } catch (ClassNotFoundException e) {
@@ -52,26 +97,26 @@ public class Db2JdbcRunner {
             try (Connection conn = DriverManager.getConnection(url, user, password)) {
                 switch (action.toLowerCase()) {
                     case "execute":
-                        if (args.length < 5) {
+                        if (actionArgs.isEmpty()) {
                             throw new IllegalArgumentException("SQL query required for execute action");
                         }
-                        executeSql(conn, args[4]);
+                        executeSql(conn, actionArgs.get(0));
                         break;
 
                     case "call":
-                        if (args.length < 5) {
+                        if (actionArgs.isEmpty()) {
                             throw new IllegalArgumentException("Routine name required for call action");
                         }
-                        String routineName = args[4];
-                        String paramsJson = args.length > 5 ? args[5] : "[]";
+                        String routineName = actionArgs.get(0);
+                        String paramsJson  = actionArgs.size() > 1 ? actionArgs.get(1) : "[]";
                         callProcedure(conn, routineName, paramsJson);
                         break;
 
                     case "getcolumns":
-                        if (args.length < 6) {
+                        if (actionArgs.size() < 2) {
                             throw new IllegalArgumentException("Schema and Table required for getColumns action");
                         }
-                        getColumns(conn, args[4], args[5]);
+                        getColumns(conn, actionArgs.get(0), actionArgs.get(1));
                         break;
 
                     default:
@@ -84,6 +129,8 @@ public class Db2JdbcRunner {
             System.exit(2);
         }
     }
+
+    // ─── SQL execution ───────────────────────────────────────────────────────────
 
     private static void executeSql(Connection conn, String sql) throws Exception {
         List<List<Map<String, Object>>> allResults = new ArrayList<>();
@@ -105,8 +152,7 @@ public class Db2JdbcRunner {
     }
 
     private static void callProcedure(Connection conn, String routineName, String paramsJson) throws Exception {
-        // Simple call procedure runner
-        List<Object> paramList = parseSimpleJsonArray(paramsJson);
+        List<Object> paramList = parseJsonArray(paramsJson);
         StringBuilder callSql = new StringBuilder("CALL ").append(routineName);
         if (!paramList.isEmpty()) {
             callSql.append("(");
@@ -120,12 +166,10 @@ public class Db2JdbcRunner {
         List<Object> results = new ArrayList<>();
 
         try (CallableStatement cstmt = conn.prepareCall(callSql.toString())) {
-            int outCount = 0;
             for (int i = 0; i < paramList.size(); i++) {
                 Object p = paramList.get(i);
                 int paramType = 1; // Default INPUT
                 Object data = p;
-
                 if (p instanceof Map) {
                     Map<?, ?> pMap = (Map<?, ?>) p;
                     if (pMap.containsKey("ParamType")) {
@@ -133,23 +177,20 @@ public class Db2JdbcRunner {
                     }
                     data = pMap.get("Data");
                 }
-
                 int paramIndex = i + 1;
-                if (paramType == 1) { // INPUT
+                if (paramType == 1) {         // INPUT
                     cstmt.setObject(paramIndex, data);
-                } else if (paramType == 2) { // OUTPUT
+                } else if (paramType == 2) {  // OUTPUT
                     cstmt.registerOutParameter(paramIndex, Types.VARCHAR);
-                    outCount++;
-                } else if (paramType == 3) { // INOUT
+                } else if (paramType == 3) {  // INOUT
                     cstmt.setObject(paramIndex, data);
                     cstmt.registerOutParameter(paramIndex, Types.VARCHAR);
-                    outCount++;
                 }
             }
 
             boolean isResultSet = cstmt.execute();
 
-            // Collect OUT parameters
+            // Collect OUT/INOUT parameters
             for (int i = 0; i < paramList.size(); i++) {
                 Object p = paramList.get(i);
                 int paramType = 1;
@@ -194,52 +235,38 @@ public class Db2JdbcRunner {
         try (ResultSet rs = meta.getColumns(null, schema, table, null)) {
             while (rs.next()) {
                 Map<String, Object> col = new HashMap<>();
-                col.put("TABLE_CAT", rs.getString("TABLE_CAT"));
-                col.put("TABLE_SCHEM", rs.getString("TABLE_SCHEM"));
-                col.put("TABLE_NAME", rs.getString("TABLE_NAME"));
-                col.put("COLUMN_NAME", rs.getString("COLUMN_NAME"));
-                col.put("DATA_TYPE", rs.getInt("DATA_TYPE"));
-                col.put("TYPE_NAME", rs.getString("TYPE_NAME"));
-                col.put("COLUMN_SIZE", rs.getInt("COLUMN_SIZE"));
-                col.put("BUFFER_LENGTH", rs.getInt("BUFFER_LENGTH"));
-                col.put("DECIMAL_DIGITS", rs.getInt("DECIMAL_DIGITS"));
-                col.put("NUM_PREC_RADIX", rs.getInt("NUM_PREC_RADIX"));
-                col.put("NULLABLE", rs.getInt("NULLABLE"));
-                col.put("REMARKS", rs.getString("REMARKS"));
-                col.put("COLUMN_DEF", rs.getString("COLUMN_DEF"));
-                col.put("SQL_DATA_TYPE", rs.getInt("SQL_DATA_TYPE"));
+                col.put("TABLE_CAT",        rs.getString("TABLE_CAT"));
+                col.put("TABLE_SCHEM",      rs.getString("TABLE_SCHEM"));
+                col.put("TABLE_NAME",       rs.getString("TABLE_NAME"));
+                col.put("COLUMN_NAME",      rs.getString("COLUMN_NAME"));
+                col.put("DATA_TYPE",        rs.getInt("DATA_TYPE"));
+                col.put("TYPE_NAME",        rs.getString("TYPE_NAME"));
+                col.put("COLUMN_SIZE",      rs.getInt("COLUMN_SIZE"));
+                col.put("BUFFER_LENGTH",    rs.getInt("BUFFER_LENGTH"));
+                col.put("DECIMAL_DIGITS",   rs.getInt("DECIMAL_DIGITS"));
+                col.put("NUM_PREC_RADIX",   rs.getInt("NUM_PREC_RADIX"));
+                col.put("NULLABLE",         rs.getInt("NULLABLE"));
+                col.put("REMARKS",          rs.getString("REMARKS"));
+                col.put("COLUMN_DEF",       rs.getString("COLUMN_DEF"));
+                col.put("SQL_DATA_TYPE",    rs.getInt("SQL_DATA_TYPE"));
                 col.put("SQL_DATETIME_SUB", rs.getInt("SQL_DATETIME_SUB"));
-                col.put("CHAR_OCTET_LENGTH", rs.getInt("CHAR_OCTET_LENGTH"));
+                col.put("CHAR_OCTET_LENGTH",rs.getInt("CHAR_OCTET_LENGTH"));
                 col.put("ORDINAL_POSITION", rs.getInt("ORDINAL_POSITION"));
-                col.put("IS_NULLABLE", rs.getString("IS_NULLABLE"));
+                col.put("IS_NULLABLE",      rs.getString("IS_NULLABLE"));
                 columns.add(col);
             }
         }
         System.out.println(toJson(columns));
     }
 
-    private static List<Map<String, Object>> resultSetToListOfMaps(ResultSet rs) throws Exception {
-        List<Map<String, Object>> list = new ArrayList<>();
-        ResultSetMetaData meta = rs.getMetaData();
-        int colCount = meta.getColumnCount();
-        while (rs.next()) {
-            Map<String, Object> row = new HashMap<>();
-            for (int i = 1; i <= colCount; i++) {
-                String colName = meta.getColumnLabel(i);
-                Object val = rs.getObject(i);
-                row.put(colName, val);
-            }
-            list.add(row);
-        }
-        return list;
-    }
+    // ─── JSON serialisation ───────────────────────────────────────────────────────
 
     private static String toJson(Object obj) {
         if (obj == null) return "null";
         if (obj instanceof String) {
             return "\"" + escapeJson((String) obj) + "\"";
         }
-        if (obj instanceof Number || obj instanceof Boolean) {
+        if (obj instanceof Boolean || obj instanceof Number) {
             return obj.toString();
         }
         if (obj instanceof List) {
@@ -270,40 +297,169 @@ public class Db2JdbcRunner {
 
     private static String escapeJson(String s) {
         if (s == null) return "";
-        return s.replace("\\", "\\\\")
-                .replace("\"", "\\\"")
-                .replace("\b", "\\b")
-                .replace("\f", "\\f")
-                .replace("\n", "\\n")
-                .replace("\r", "\\r")
-                .replace("\t", "\\t");
+        StringBuilder sb = new StringBuilder(s.length() + 8);
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\': sb.append("\\\\"); break;
+                case '"':  sb.append("\\\""); break;
+                case '\b': sb.append("\\b");  break;
+                case '\f': sb.append("\\f");  break;
+                case '\n': sb.append("\\n");  break;
+                case '\r': sb.append("\\r");  break;
+                case '\t': sb.append("\\t");  break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        return sb.toString();
     }
 
-    private static List<Object> parseSimpleJsonArray(String json) {
-        List<Object> list = new ArrayList<>();
-        if (json == null || json.trim().isEmpty() || json.equals("[]")) {
-            return list;
+    // ─── JSON parsing (minimal but correct for our schema) ────────────────────────
+    //
+    // Parses a JSON object at the top level (credential envelope) and a JSON array
+    // (parameter list). Handles strings, numbers, booleans, null, nested objects and
+    // arrays. Handles Unicode escape sequences in string values. Sufficient for the
+    // structured payloads produced by JSON.stringify on the Node.js side.
+
+    /** Parse a JSON array string and return a List of Java objects. */
+    static List<Object> parseJsonArray(String json) throws Exception {
+        if (json == null) json = "";
+        String s = json.trim();
+        if (s.isEmpty() || s.equals("[]")) return new ArrayList<>();
+        if (!s.startsWith("[")) throw new Exception("Expected JSON array, got: " + s.substring(0, Math.min(20, s.length())));
+        int[] pos = {0};
+        return (List<Object>) parseValue(s, pos);
+    }
+
+    /** Parse a JSON object string and return a Map of String -> Object. */
+    @SuppressWarnings("unchecked")
+    static Map<String, Object> parseJsonObject(String json) throws Exception {
+        if (json == null) json = "{}";
+        String s = json.trim();
+        if (!s.startsWith("{")) throw new Exception("Expected JSON object, got: " + s.substring(0, Math.min(20, s.length())));
+        int[] pos = {0};
+        return (Map<String, Object>) parseValue(s, pos);
+    }
+
+    private static Object parseValue(String s, int[] pos) throws Exception {
+        skipWhitespace(s, pos);
+        if (pos[0] >= s.length()) throw new Exception("Unexpected end of JSON");
+        char c = s.charAt(pos[0]);
+        if (c == '"')  return parseString(s, pos);
+        if (c == '{')  return parseObject(s, pos);
+        if (c == '[')  return parseArray(s, pos);
+        if (c == 't')  { pos[0] += 4; return Boolean.TRUE; }
+        if (c == 'f')  { pos[0] += 5; return Boolean.FALSE; }
+        if (c == 'n')  { pos[0] += 4; return null; }
+        if (c == '-' || Character.isDigit(c)) return parseNumber(s, pos);
+        throw new Exception("Unexpected character '" + c + "' at position " + pos[0]);
+    }
+
+    private static Map<String, Object> parseObject(String s, int[] pos) throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        pos[0]++; // skip '{'
+        skipWhitespace(s, pos);
+        if (pos[0] < s.length() && s.charAt(pos[0]) == '}') { pos[0]++; return map; }
+        while (pos[0] < s.length()) {
+            skipWhitespace(s, pos);
+            String key = parseString(s, pos);
+            skipWhitespace(s, pos);
+            if (pos[0] >= s.length() || s.charAt(pos[0]) != ':') throw new Exception("Expected ':' in object");
+            pos[0]++;
+            Object val = parseValue(s, pos);
+            map.put(key, val);
+            skipWhitespace(s, pos);
+            if (pos[0] >= s.length()) break;
+            char next = s.charAt(pos[0]);
+            if (next == '}') { pos[0]++; break; }
+            if (next == ',') { pos[0]++; } else { throw new Exception("Expected ',' or '}' in object"); }
         }
-        String trimmed = json.trim();
-        if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
-            trimmed = trimmed.substring(1, trimmed.length() - 1).trim();
-            if (!trimmed.isEmpty()) {
-                String[] parts = trimmed.split(",");
-                for (String part : parts) {
-                    part = part.trim();
-                    if (part.startsWith("\"") && part.endsWith("\"")) {
-                        list.add(part.substring(1, part.length() - 1));
-                    } else if ("true".equalsIgnoreCase(part) || "false".equalsIgnoreCase(part)) {
-                        list.add(Boolean.parseBoolean(part));
-                    } else {
-                        try {
-                            list.add(Integer.parseInt(part));
-                        } catch (NumberFormatException e) {
-                            list.add(part);
-                        }
-                    }
+        return map;
+    }
+
+    private static List<Object> parseArray(String s, int[] pos) throws Exception {
+        List<Object> list = new ArrayList<>();
+        pos[0]++; // skip '['
+        skipWhitespace(s, pos);
+        if (pos[0] < s.length() && s.charAt(pos[0]) == ']') { pos[0]++; return list; }
+        while (pos[0] < s.length()) {
+            list.add(parseValue(s, pos));
+            skipWhitespace(s, pos);
+            if (pos[0] >= s.length()) break;
+            char next = s.charAt(pos[0]);
+            if (next == ']') { pos[0]++; break; }
+            if (next == ',') { pos[0]++; } else { throw new Exception("Expected ',' or ']' in array"); }
+        }
+        return list;
+    }
+
+    private static String parseString(String s, int[] pos) throws Exception {
+        if (s.charAt(pos[0]) != '"') throw new Exception("Expected '\"' at position " + pos[0]);
+        pos[0]++;
+        StringBuilder sb = new StringBuilder();
+        while (pos[0] < s.length()) {
+            char c = s.charAt(pos[0]++);
+            if (c == '"') return sb.toString();
+            if (c == '\\') {
+                if (pos[0] >= s.length()) throw new Exception("Unexpected end of string escape");
+                char esc = s.charAt(pos[0]++);
+                switch (esc) {
+                    case '"': sb.append('"'); break;
+                    case '\\': sb.append('\\'); break;
+                    case '/': sb.append('/'); break;
+                    case 'b': sb.append('\b'); break;
+                    case 'f': sb.append('\f'); break;
+                    case 'n': sb.append('\n'); break;
+                    case 'r': sb.append('\r'); break;
+                    case 't': sb.append('\t'); break;
+                    case 'u':
+                        String hex = s.substring(pos[0], Math.min(pos[0] + 4, s.length()));
+                        sb.append((char) Integer.parseInt(hex, 16));
+                        pos[0] += 4;
+                        break;
+                    default: sb.append(esc);
                 }
+            } else {
+                sb.append(c);
             }
+        }
+        throw new Exception("Unterminated string");
+    }
+
+    private static Number parseNumber(String s, int[] pos) {
+        int start = pos[0];
+        if (s.charAt(pos[0]) == '-') pos[0]++;
+        while (pos[0] < s.length() && (Character.isDigit(s.charAt(pos[0])) || s.charAt(pos[0]) == '.' || s.charAt(pos[0]) == 'e' || s.charAt(pos[0]) == 'E' || s.charAt(pos[0]) == '+' || s.charAt(pos[0]) == '-')) {
+            pos[0]++;
+        }
+        String num = s.substring(start, pos[0]);
+        if (num.contains(".") || num.contains("e") || num.contains("E")) {
+            return Double.parseDouble(num);
+        }
+        return Long.parseLong(num);
+    }
+
+    private static void skipWhitespace(String s, int[] pos) {
+        while (pos[0] < s.length() && Character.isWhitespace(s.charAt(pos[0]))) pos[0]++;
+    }
+
+    private static List<Map<String, Object>> resultSetToListOfMaps(ResultSet rs) throws Exception {
+        List<Map<String, Object>> list = new ArrayList<>();
+        ResultSetMetaData meta = rs.getMetaData();
+        int colCount = meta.getColumnCount();
+        while (rs.next()) {
+            Map<String, Object> row = new HashMap<>();
+            for (int i = 1; i <= colCount; i++) {
+                String colName = meta.getColumnLabel(i);
+                Object val = rs.getObject(i);
+                row.put(colName, val);
+            }
+            list.add(row);
         }
         return list;
     }

--- a/src/java/Db2JdbcRunner.java
+++ b/src/java/Db2JdbcRunner.java
@@ -40,12 +40,13 @@ public class Db2JdbcRunner {
         String password = args[3];
 
         try {
-            // Register DB2 JDBC driver
+            // Register DB2 JDBC driver (com.ibm.db2.jcc.DB2Driver)
             try {
                 Class.forName("com.ibm.db2.jcc.DB2Driver");
             } catch (ClassNotFoundException e) {
-                // Fallback driver name if needed
-                Class.forName("com.ibm.db2.jdbc.app.DB2Driver");
+                System.err.println("JDBC Error: IBM Db2 JDBC Driver class 'com.ibm.db2.jcc.DB2Driver' not found in classpath.");
+                System.err.println("Please check that jdbcJarPath contains db2jcc4.jar or db2jcc.jar.");
+                System.exit(2);
             }
 
             try (Connection conn = DriverManager.getConnection(url, user, password)) {

--- a/src/rest/session/doc/IDB2Session.ts
+++ b/src/rest/session/doc/IDB2Session.ts
@@ -59,4 +59,39 @@ export interface IDB2Session {
      * @memberof IDB2Session
      */
     sslFile?: string;
+
+    /**
+     * Driver type used to connect to Db2: "odbc" or "jdbc"
+     * @type {"odbc" | "jdbc"}
+     * @memberof IDB2Session
+     */
+    driverType?: "odbc" | "jdbc";
+
+    /**
+     * Path to the Db2 JDBC driver JAR file (e.g. db2jcc4.jar) or directory containing it
+     * @type {string}
+     * @memberof IDB2Session
+     */
+    jdbcJarPath?: string;
+
+    /**
+     * Path to the Db2 JDBC license JAR file (e.g. db2jcc_license_cisuz.jar) or directory containing it
+     * @type {string}
+     * @memberof IDB2Session
+     */
+    jdbcLicensePath?: string;
+
+    /**
+     * Path to java executable to use for JDBC connections (defaults to "java")
+     * @type {string}
+     * @memberof IDB2Session
+     */
+    javaPath?: string;
+
+    /**
+     * Additional JDBC connection properties as a formatted string or key-value record
+     * @type {string | Record<string, string>}
+     * @memberof IDB2Session
+     */
+    jdbcProperties?: string | Record<string, string>;
 }


### PR DESCRIPTION
This is a quick, AI generated POC for a change that will support JDBC on par with ODBC.

Adds an alternative JDBC driver pathway (`--driver-type jdbc`) for connecting to
Db2 for z/OS. Users who cannot install the ODBC driver or obtain an ODBC license
key can now connect using the standard IBM Db2 JDBC driver (`db2jcc4.jar`) and its
z/OS license JAR (`db2jcc_license_cisuz.jar`) with a local Java runtime.

The ODBC path is completely unchanged and remains the default.

**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->